### PR TITLE
Workshop work

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,22 +127,27 @@ function main(argv, onResponse) {
 function tcurl(opts) {
     var logger = Logger(opts);
     var spec;
-    if (opts.thrift) {
-        var specs = {};
-        var files = fs.readdirSync(opts.thrift);
-        files.forEach(function eachFile(file) {
-            var match = /([^\/]+)\.thrift$/.exec(file);
-            if (match) {
-                var serviceName = match[1];
-                var fileName = match[0];
-                specs[serviceName] =
-                    fs.readFileSync(path.join(opts.thrift, fileName), 'utf8');
-            }
-        });
 
-        spec = specs[opts.service];
-        if (!spec) {
-            throw new Error('Spec for service unavailable: ' + opts.service);
+    if (opts.thrift) {
+        var optStat = fs.statSync(opts.thrift);
+        if (optStat.isFile()) {
+            spec = fs.readFileSync(opts.thrift, 'utf8');
+        } else {
+            var specs = {};
+            var files = fs.readdirSync(opts.thrift);
+            files.forEach(function eachFile(file) {
+                var match = /([^\/]+)\.thrift$/.exec(file);
+                if (match) {
+                    var serviceName = match[1];
+                    var fileName = match[0];
+                    specs[serviceName] = fs.readFileSync(path.join(opts.thrift, fileName), 'utf8');
+                }
+            });
+
+            spec = specs[opts.service];
+            if (!spec) {
+                throw new Error('Spec for service unavailable: ' + opts.service);
+            }
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function execMain(str, cb) {
 }
 
 function help() {
-    console.log('tcurl -p host:port <service> <endpoint> [options]');
+    console.log('tcurl [-H <hostlist> | -p host:port] <service> <endpoint> [options]');
     console.log('  ');
     console.log('  Options: ');
     // TODO @file; @- stdin.
@@ -79,12 +79,18 @@ function parseArgs(argv) {
     var head = argv['2'] || argv.arg2 || '';
 
     var uri = argv.p || argv.peer;
+    var hostlist = argv.H || argv.hostlist;
     var thrift = argv.t || argv.thrift;
     var http = argv.http;
     var json = argv.j || argv.J;
     var service = argv._[0];
     var endpoint = argv._[1];
     var health = argv.health;
+
+    if (hostlist) {
+        uri = JSON.parse(fs.readFileSync(hostlist))[0];
+    }
+
     var parsedUri = url.parse('tchannel://' + uri);
 
     if (parsedUri.hostname === 'localhost') {


### PR DESCRIPTION
r @Raynos @kriskowal 

Makes it so that:
- can pass a specific IDL file directly to tcurl, rather than relying on dubious directory + matching service name convention
- can pass a hostlist instead of peer (uses only single peer at present from said hostlist)