### PR TITLE
Better error on non-existent endpoint, plus linting improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,29 +45,29 @@ main.exec = execMain;
 
 module.exports = main;
 
+var minimistArgs = {
+    boolean: ['raw'],
+    alias: {
+        h: 'help',
+        p: 'peer',
+        H: 'hostlist',
+        t: 'thrift',
+        2: ['arg2', 'head'],
+        3: ['arg3', 'body'],
+        j: ['J', 'json']
+    },
+    default: {
+        head: '',
+        body: ''
+    }
+};
+
 if (require.main === module) {
-    main(minimist(process.argv.slice(2), {
-        boolean: ['raw']
-    }));
+    main(minimist(process.argv.slice(2), minimistArgs));
 }
 
 function execMain(str, cb) {
-    main(minimist(str, {
-        boolean: ['raw'],
-        alias: {
-            h: 'help',
-            p: 'peer',
-            H: 'hostlist',
-            t: 'thrift',
-            2: ['arg2', 'head'],
-            3: ['arg3', 'body'],
-            j: ['J', 'json']
-        },
-        default: {
-            head: '',
-            body: ''
-        }
-    }), cb);
+    main(minimist(str, minimistArgs), cb);
 }
 
 function help() {
@@ -243,7 +243,6 @@ function tcurl(opts) {
 
         if (err) {
             logger.log('error', err);
-            logger.log('error', err.message);
             /*eslint no-process-exit: 0*/
             process.exit(1);
         }

--- a/test/as-thrift.js
+++ b/test/as-thrift.js
@@ -98,3 +98,43 @@ test('getting an ok response', function t(assert) {
     }
 
 });
+
+test('hitting non-existent endpoint', function t(assert) {
+
+    var serviceName = 'meta';
+    var server = new TChannel({
+        serviceName: serviceName
+    });
+
+    var hostname = '127.0.0.1';
+    var port = 4040;
+    var endpoint = 'Meta::health';
+    var nonexistentEndpoint = endpoint + 'Foo';
+
+    var tchannelAsThrift = TChannelAsThrift({source: meta});
+    tchannelAsThrift.register(server, endpoint, {}, noop);
+
+    server.listen(port, hostname, onListening);
+    function onListening() {
+        var cmd = [
+            '-p', hostname + ':' + port,
+            serviceName,
+            nonexistentEndpoint,
+            '-t', path.join(__dirname, '..')
+        ];
+
+        tcurl.exec(cmd, onResponse);
+
+        function onResponse(err, resp) {
+            assert.equal(err.message,
+                nonexistentEndpoint + ' endpoint does not exist',
+                'Warned about non-existent endpoint');
+
+            server.close();
+            assert.end();
+        }
+    }
+
+    function noop() {}
+
+});


### PR DESCRIPTION
This PR implements a clearer error when you try to hit a non-existent endpoint. L281-L292 of index.js and L101-L140 of test/as-thrift.js

It also includes some refactoring because linting was not passing when I tried to commit this. 

The tests in as-thrift could be DRYed up some, but I'll do that once there are a few more tests in that file.

cc/ @Raynos @jcorbin @kriskowal 