### PR TITLE
Implement --no-strict, this time with feeling

### DIFF
--- a/test/legacy.thrift
+++ b/test/legacy.thrift
@@ -1,0 +1,9 @@
+struct Feckless {
+    1: i32 ambiguity
+}
+struct Pong {
+    1: bool pong
+}
+service Pinger {
+    Pong ping()
+}


### PR DESCRIPTION
Also cleans up the control flow. Next step would be to move from closures to prototypes.

I consolidated the meta client to re-use the existing asThrift path by defaulting the --thrift and --endpoint options, then handling the response slightly differently, but still flowing through to the same response handler.