### PR TITLE
Get Thrift IDL from Meta::thriftIDL

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,12 +49,13 @@ var packageJson = require('./package.json');
 module.exports = main;
 
 var minimistArgs = {
-    boolean: ['raw', 'strict'],
+    boolean: ['raw', 'json', 'strict'],
     alias: {
         h: 'help',
         p: 'peer',
         H: 'hostlist',
         t: 'thrift',
+        j: 'json',
         2: ['arg2', 'head'],
         3: ['arg3', 'body']
     },
@@ -92,16 +93,20 @@ main.exec = function execMain(str, delegate) {
 function help() {
     var helpMessage = [
         'tcurl [-H <hostlist> | -p host:port] <service> <endpoint> [options]',
-        '  ',
+        '',
         '  Version: ' + packageJson.version,
+        '',
         '  Options: ',
         // TODO @file; @- stdin.
-        '    -2 [data] send an arg2 blob',
-        '    -3 [data] send an arg3 blob',
+        '    --head (-2) [data] JSON or raw',
+        '    --body (-3) [data] JSON or raw',
+        '      (JSON promoted to Thrift via IDL when applicable)',
         '    --shardKey send ringpop shardKey transport header',
         '    --depth=n configure inspect printing depth',
-        '    -t [dir] directory containing Thrift files',
+        '    --thrift (-t) [dir] directory containing Thrift files',
         '    --no-strict parse Thrift loosely',
+        '    --json (-j) Use JSON argument scheme',
+        '      (default unless endpoint has ::)',
         '    --http method',
         '    --raw encode arg2 & arg3 raw',
         '    --health',
@@ -122,6 +127,19 @@ function parseArgs(argv) {
     assert(health || endpoint, 'endpoint required');
     assert(service, 'service required');
 
+    var argScheme;
+    if (argv.raw) {
+        argScheme = 'raw';
+    } else if (argv.http) {
+        argScheme = 'http';
+    } else if (argv.json) {
+        argScheme = 'json';
+    } else if (argv.thrift || health || endpoint.indexOf('::') >= 0) {
+        argScheme = 'thrift';
+    } else {
+        argScheme = 'json';
+    }
+
     return {
         head: argv.head,
         body: argv.body,
@@ -129,10 +147,10 @@ function parseArgs(argv) {
         service: service,
         endpoint: endpoint,
         peers: peers,
+        argScheme: argScheme,
         thrift: argv.thrift,
         strict: argv.strict,
         http: argv.http,
-        json: argv.json,
         raw: argv.raw,
         timeout: argv.timeout,
         depth: argv.depth,
@@ -251,15 +269,15 @@ TCurl.prototype.request = function tcurlRequest(opts, delegate) {
             headers: headers
         });
 
-        if (opts.thrift) {
+        if (opts.argScheme === 'thrift') {
             self.asThrift(opts, request, delegate, done);
-        } else if (opts.http) {
+        } else if (opts.argScheme === 'http') {
             self.asHTTP(opts, client, subChan, delegate, done);
-        } else if (opts.raw) {
-            self.asRaw(opts, request, delegate, done);
-        } else {
+        } else if (opts.argScheme === 'json') {
             self.asJSON(opts, request, delegate, done);
             // TODO fix argument order for each of these
+        } else {
+            self.asRaw(opts, request, delegate, done);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ var TChannel = require('tchannel');
 var TChannelAsThrift = require('tchannel/as/thrift');
 var TChannelAsJSON = require('tchannel/as/json');
 var minimist = require('minimist');
-var myLocalIp = require('my-local-ip');
 var DebugLogtron = require('debug-logtron');
 
 var fmt = require('util').format;
@@ -37,7 +36,6 @@ var console = require('console');
 var process = require('process');
 var fs = require('fs');
 var path = require('path');
-var url = require('url');
 var assert = require('assert');
 
 var safeJsonParse = require('safe-json-parse/tuple');
@@ -120,22 +118,6 @@ function parseArgs(argv) {
 
     var peers = argv.hostlist ?
         JSON.parse(fs.readFileSync(argv.hostlist)) : [argv.peer];
-
-    var ip;
-    function normalizePeer(address) {
-        if (!ip) {
-            ip = myLocalIp();
-        }
-        var parsedUri = url.parse('tchannel://' + address);
-        if (parsedUri.hostname === 'localhost') {
-            parsedUri.hostname = ip;
-        }
-        assert(parsedUri.hostname, 'host required');
-        assert(parsedUri.port, 'port required');
-        return parsedUri.hostname + ':' + parsedUri.port;
-    }
-
-    peers = peers.map(normalizePeer);
 
     assert(health || endpoint, 'endpoint required');
     assert(service, 'service required');
@@ -250,6 +232,7 @@ TCurl.prototype.request = function tcurlRequest(opts, delegate) {
     });
 
     var peer = subChan.peers.choosePeer();
+    assert(peer, 'peer required');
     // TODO: the host option should be called peer, hostPort, or address
     client.waitForIdentified({host: peer.hostPort}, onIdentified);
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "process": "^0.11.0",
     "readable-stream": "^1.0.33",
     "safe-json-parse": "^4.0.0",
-    "tchannel": "2.10.1"
+    "tchannel": "3.3.0"
   },
   "devDependencies": {
     "coveralls": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "debug-logtron": "^3.2.0",
     "minimist": "^1.1.1",
-    "my-local-ip": "^1.0.0",
     "process": "^0.11.0",
     "readable-stream": "^1.0.33",
     "safe-json-parse": "^4.0.0",


### PR DESCRIPTION
This allows TCurl to automatically obtain a ThriftIDL file from the service if one was not provided.