### PR TITLE
Tests use available port instead of hardcoded port

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "devDependencies": {
     "coveralls": "^2.10.0",
     "format-stack": "4.0.0",
-    "get-port": "^1.0.0",
     "istanbul": "^0.3.5",
     "itape": "^1.5.0",
     "lint-trap": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "coveralls": "^2.10.0",
     "format-stack": "4.0.0",
+    "get-port": "^1.0.0",
     "istanbul": "^0.3.5",
     "itape": "^1.5.0",
     "lint-trap": "^1.0.0",

--- a/test/as-http.js
+++ b/test/as-http.js
@@ -25,7 +25,6 @@
 var http = require('http');
 var ReadySignal = require('ready-signal/counted');
 var test = require('tape');
-var getPort = require('get-port');
 var tcurl = require('../index.js');
 var TChannel = require('tchannel');
 var TChannelAsHTTP = require('tchannel/as/http.js');
@@ -83,29 +82,20 @@ test('getting an ok response', function t(assert) {
        special: 'CQ'
     };
 
-    var readyPorts = ReadySignal(2);
     var ready = ReadySignal(2);
 
-    getPort(function onPort(err, availablePort) {
-        if (err) {
-            assert.error(err);
-        }
-        port = availablePort;
-        readyPorts.signal();
-    });
+    function onServerListen() {
+        port = server.address().port;
+        ready.signal();
+    }
 
-    getPort(function onPort(err, availablePort) {
-        if (err) {
-            assert.error(err);
-        }
-        httpPort = availablePort;
-        readyPorts.signal();
-    });
+    function onHttpServerListen() {
+        httpPort = httpServer.address().port;
+        ready.signal();
+    }
 
-    readyPorts(function onPorts() {
-        server.listen(port, hostname, ready.signal);
-        httpServer.listen(httpPort, hostname, ready.signal);
-    });
+    server.listen(0, hostname, onServerListen);
+    httpServer.listen(0, hostname, onHttpServerListen);
 
     ready(onListening);
 

--- a/test/as-http.js
+++ b/test/as-http.js
@@ -25,39 +25,45 @@
 var http = require('http');
 var ReadySignal = require('ready-signal/counted');
 var test = require('tape');
+var getPort = require('get-port');
 var tcurl = require('../index.js');
 var TChannel = require('tchannel');
 var TChannelAsHTTP = require('tchannel/as/http.js');
 
 test('getting an ok response', function t(assert) {
+    var hostname = '127.0.0.1';
     var serviceName = 'service';
+    var body = 'Hello Server';
+    var port;
+    var httpPort;
+
     var server = new TChannel({});
     var asHttpServer = TChannelAsHTTP();
     var subServer = server.makeSubChannel({
         serviceName: serviceName,
         streamed: true
     });
-    var httpServer = http.createServer(
-        function onRequest(hreq, hres) {
-            assert.equal(hreq.url, '/echo');
+    var httpServer = http.createServer(function onRequest(hreq, hres) {
+        assert.equal(hreq.url, '/echo');
 
-            assert.equals(hreq.headers.special, 'CQ', 'header should be CQ');
-            hreq.on('data', function onData(chunk) {
-                assert.equals(
-                    String(chunk),
-                    'Hello Server',
-                    'body should equal');
-            });
-            hreq.on('end', function onData() {
-              hres.writeHead(200, 'OK', {'Content-Type': 'text/plain'});
-              hres.end('Hello Test');
-          });
+        assert.equals(hreq.headers.special, 'CQ', 'header should be CQ');
+        hreq.on('data', function onData(chunk) {
+            assert.equals(
+                String(chunk),
+                body,
+                'body should equal');
         });
+        hreq.on('end', function onData() {
+          hres.writeHead(200, 'OK', {'Content-Type': 'text/plain'});
+          hres.end('Hello Test');
+      });
+    });
+
     asHttpServer.setHandler(subServer, function onRequest(req, res) {
         asHttpServer.forwardToHTTP(
             subServer, {
-                host: '127.0.0.1',
-                port: 8081
+                host: hostname,
+                port: httpPort
             },
             req,
             res,
@@ -69,8 +75,6 @@ test('getting an ok response', function t(assert) {
         );
     });
 
-    var hostname = '127.0.0.1';
-    var port = 4040;
     var endpoint = '/echo';
     var method = 'POST';
     var head = {
@@ -78,12 +82,33 @@ test('getting an ok response', function t(assert) {
        'Accept-Language': 'en-US',
        special: 'CQ'
     };
-    var body = 'Hello Server';
 
+    var readyPorts = ReadySignal(2);
     var ready = ReadySignal(2);
-    server.listen(port, hostname, ready.signal);
-    httpServer.listen(8081, '127.0.0.1', ready.signal);
+
+    getPort(function onPort(err, availablePort) {
+        if (err) {
+            assert.error(err);
+        }
+        port = availablePort;
+        readyPorts.signal();
+    });
+
+    getPort(function onPort(err, availablePort) {
+        if (err) {
+            assert.error(err);
+        }
+        httpPort = availablePort;
+        readyPorts.signal();
+    });
+
+    readyPorts(function onPorts() {
+        server.listen(port, hostname, ready.signal);
+        httpServer.listen(httpPort, hostname, ready.signal);
+    });
+
     ready(onListening);
+
     function onListening() {
         var cmd = [
             '-p',

--- a/test/as-json.js
+++ b/test/as-json.js
@@ -24,6 +24,7 @@
 
 var timers = require('timers');
 var test = require('tape');
+var getPort = require('get-port');
 var tcurl = require('../index.js');
 var TChannel = require('tchannel');
 var TChannelJSON = require('tchannel/as/json.js');
@@ -50,7 +51,7 @@ test('getting an ok response', function t(assert) {
     };
 
     var hostname = '127.0.0.1';
-    var port = 4040;
+    var port;
     var endpoint = 'echo';
     var head = {some: 'echo-head'};
     var body = {some: 'body'};
@@ -59,7 +60,14 @@ test('getting an ok response', function t(assert) {
     var tchannelJSON = TChannelJSON();
     tchannelJSON.register(server, endpoint, opts, echo);
 
-    server.listen(port, hostname, onListening);
+    getPort(function onPort(err, availablePort) {
+        if (err) {
+            assert.error(err);
+        }
+        port = availablePort;
+        server.listen(port, hostname, onListening);
+    });
+
     function onListening() {
         var cmd = [
             '-p', hostname + ':' + port,
@@ -123,7 +131,7 @@ test('timeouts work', function t(assert) {
     };
 
     var hostname = '127.0.0.1';
-    var port = 4040;
+    var port;
     var endpoint = 'echo';
     var head = {some: 'echo-head'};
     var body = {some: 'body'};
@@ -132,7 +140,14 @@ test('timeouts work', function t(assert) {
     var tchannelJSON = TChannelJSON();
     tchannelJSON.register(server, endpoint, opts, slowEcho);
 
-    server.listen(port, hostname, onListening);
+    getPort(function onPort(err, availablePort) {
+        if (err) {
+            assert.error(err);
+        }
+        port = availablePort;
+        server.listen(port, hostname, onListening);
+    });
+
     function onListening() {
         var cmd = [
             '-p', hostname + ':' + port,

--- a/test/as-json.js
+++ b/test/as-json.js
@@ -24,7 +24,6 @@
 
 var timers = require('timers');
 var test = require('tape');
-var getPort = require('get-port');
 var tcurl = require('../index.js');
 var TChannel = require('tchannel');
 var TChannelJSON = require('tchannel/as/json.js');
@@ -60,13 +59,12 @@ test('getting an ok response', function t(assert) {
     var tchannelJSON = TChannelJSON();
     tchannelJSON.register(server, endpoint, opts, echo);
 
-    getPort(function onPort(err, availablePort) {
-        if (err) {
-            assert.error(err);
-        }
-        port = availablePort;
-        server.listen(port, hostname, onListening);
-    });
+    function onServerListen() {
+        port = server.address().port;
+        onListening();
+    }
+
+    server.listen(0, hostname, onServerListen);
 
     function onListening() {
         var cmd = [
@@ -140,13 +138,12 @@ test('timeouts work', function t(assert) {
     var tchannelJSON = TChannelJSON();
     tchannelJSON.register(server, endpoint, opts, slowEcho);
 
-    getPort(function onPort(err, availablePort) {
-        if (err) {
-            assert.error(err);
-        }
-        port = availablePort;
-        server.listen(port, hostname, onListening);
-    });
+    function onServerListen() {
+        port = server.address().port;
+        onListening();
+    }
+
+    server.listen(0, hostname, onServerListen);
 
     function onListening() {
         var cmd = [

--- a/test/as-thrift.js
+++ b/test/as-thrift.js
@@ -25,7 +25,6 @@
 var test = require('tape');
 var fs = require('fs');
 var path = require('path');
-var getPort = require('get-port');
 var tcurl = require('../index.js');
 var TChannel = require('tchannel');
 var TChannelAsThrift = require('tchannel/as/thrift.js');
@@ -48,13 +47,12 @@ test('getting an ok response', function t(assert) {
     var tchannelAsThrift = TChannelAsThrift({source: meta});
     tchannelAsThrift.register(server, endpoint, opts, health);
 
-    getPort(function onPort(err, availablePort) {
-        if (err) {
-            assert.error(err);
-        }
-        port = availablePort;
-        server.listen(port, hostname, onListening);
-    });
+    function onServerListen() {
+        port = server.address().port;
+        onListening();
+    }
+
+    server.listen(0, hostname, onServerListen);
 
     function onListening() {
         var cmd = [
@@ -124,13 +122,12 @@ test('hitting non-existent endpoint', function t(assert) {
     var tchannelAsThrift = TChannelAsThrift({source: meta});
     tchannelAsThrift.register(server, endpoint, {}, noop);
 
-    getPort(function onPort(err, availablePort) {
-        if (err) {
-            assert.error(err);
-        }
-        port = availablePort;
-        server.listen(port, hostname, onListening);
-    });
+    function onServerListen() {
+        port = server.address().port;
+        onListening();
+    }
+
+    server.listen(0, hostname, onServerListen);
 
     function onListening() {
         var cmd = [
@@ -170,13 +167,12 @@ test('fails to run for invalid thrift', function t(assert) {
     var hostname = '127.0.0.1';
     var port;
 
-    getPort(function onPort(err, availablePort) {
-        if (err) {
-            assert.error(err);
-        }
-        port = availablePort;
-        server.listen(port, hostname, onListening);
-    });
+    function onServerListen() {
+        port = server.address().port;
+        onListening();
+    }
+
+    server.listen(0, hostname, onServerListen);
 
     function onListening() {
 
@@ -224,13 +220,12 @@ test('tolerates loose thrift with --no-strict', function t(assert) {
     var hostname = '127.0.0.1';
     var port;
 
-    getPort(function onPort(err, availablePort) {
-        if (err) {
-            assert.error(err);
-        }
-        port = availablePort;
-        server.listen(port, hostname, onListening);
-    });
+    function onServerListen() {
+        port = server.address().port;
+        onListening();
+    }
+
+    server.listen(0, hostname, onServerListen);
 
     var tchannelAsThrift = TChannelAsThrift({source: legacy, strict: false});
     tchannelAsThrift.register(server, 'Pinger::ping', {}, ping);

--- a/test/health.js
+++ b/test/health.js
@@ -25,6 +25,7 @@
 /*eslint max-params: [2, 5] */
 
 var test = require('tape');
+var getPort = require('get-port');
 var tcurl = require('../index.js');
 var TChannel = require('tchannel');
 var TChannelAsThrift = require('tchannel/as/thrift');
@@ -65,11 +66,19 @@ test('getting an ok', function t(assert) {
     };
 
     var hostname = '127.0.0.1';
-    var port = 4040;
+    var port;
     var endpoint = 'Meta::health';
     var serviceName = 'server';
     asThrift.register(server, endpoint, opts, goodHealth);
-    server.listen(port, hostname, onListening);
+
+    getPort(function onPort(err, availablePort) {
+        if (err) {
+            assert.error(err);
+        }
+        port = availablePort;
+        server.listen(port, hostname, onListening);
+    });
+
     function onListening() {
         var cmd = [
             '-p', hostname + ':' + port,
@@ -104,11 +113,19 @@ test('getting a notOk', function t(assert) {
     };
 
     var hostname = '127.0.0.1';
-    var port = 4040;
+    var port;
     var endpoint = 'Meta::health';
     var serviceName = 'server';
     asThrift.register(server, endpoint, opts, badHealth);
-    server.listen(port, hostname, onListening);
+
+    getPort(function onPort(err, availablePort) {
+        if (err) {
+            assert.error(err);
+        }
+        port = availablePort;
+        server.listen(port, hostname, onListening);
+    });
+
     function onListening() {
         var cmd = [
             '-p', hostname + ':' + port,
@@ -144,11 +161,19 @@ test('getting an error', function t(assert) {
     };
 
     var hostname = '127.0.0.1';
-    var port = 4040;
+    var port;
     var endpoint = 'Meta::health';
     var serviceName = 'server';
     asThrift.register(server, endpoint, opts, veryBadHealth);
-    server.listen(port, hostname, onListening);
+
+    getPort(function onPort(err, availablePort) {
+        if (err) {
+            assert.error(err);
+        }
+        port = availablePort;
+        server.listen(port, hostname, onListening);
+    });
+
     function onListening() {
         var cmd = [
             '-p', hostname + ':' + port,
@@ -186,11 +211,19 @@ test('test healthy endpoint with subprocess', function t(assert) {
     };
 
     var hostname = '127.0.0.1';
-    var port = 4040;
+    var port;
     var endpoint = 'Meta::health';
     var serviceName = 'server';
     asThrift.register(server, endpoint, opts, goodHealth);
-    server.listen(port, hostname, onListening);
+
+    getPort(function onPort(err, availablePort) {
+        if (err) {
+            assert.error(err);
+        }
+        port = availablePort;
+        server.listen(port, hostname, onListening);
+    });
+
     function onListening() {
         var cmd = [
             path.join(__dirname, '..', 'index.js'),
@@ -234,11 +267,19 @@ test('test un-healthy endpoint with subprocess', function t(assert) {
     };
 
     var hostname = '127.0.0.1';
-    var port = 4040;
+    var port;
     var endpoint = 'Meta::health';
     var serviceName = 'server';
     asThrift.register(server, endpoint, opts, badHealth);
-    server.listen(port, hostname, onListening);
+
+    getPort(function onPort(err, availablePort) {
+        if (err) {
+            assert.error(err);
+        }
+        port = availablePort;
+        server.listen(port, hostname, onListening);
+    });
+
     function onListening() {
         var cmd = [
             path.join(__dirname, '..', 'index.js'),
@@ -274,21 +315,28 @@ test('test un-healthy endpoint with subprocess', function t(assert) {
 
 test('test non-existent service with subprocess', function t(assert) {
     var hostname = '127.0.0.1';
-    var port = 4040;
+    var port;
     var serviceName = 'server';
 
-    var cmd = [
-        path.join(__dirname, '..', 'index.js'),
-        '-p', hostname + ':' + port,
-        serviceName,
-        null,
-        '--health'
-    ];
+    getPort(function onPort(err, availablePort) {
+        if (err) {
+            assert.error(err);
+        }
+        port = availablePort;
 
-    var proc = spawn('node', cmd);
-    proc.stdout.setEncoding('utf-8');
-    proc.stdout.on('data', onStdout);
-    proc.on('exit', onExit);
+        var cmd = [
+            path.join(__dirname, '..', 'index.js'),
+            '-p', hostname + ':' + port,
+            serviceName,
+            null,
+            '--health'
+        ];
+
+        var proc = spawn('node', cmd);
+        proc.stdout.setEncoding('utf-8');
+        proc.stdout.on('data', onStdout);
+        proc.on('exit', onExit);
+    });
 
     function onStdout(line) {
         assert.equal(line, 'NOT OK\n', 'expected stdout');

--- a/test/health.js
+++ b/test/health.js
@@ -313,7 +313,6 @@ test('test non-existent service with subprocess', function t(assert) {
     var port;
     var serviceName = 'server';
     var server = net.createServer();
-    server.unref();
 
     function onServerListen() {
         port = server.address().port;


### PR DESCRIPTION
@kriskowal 

This allows the tests to pass on a server where port 4040 or 8081 are in use.

