### PR TITLE
Change sendRequest to forwardToTChannel

### DIFF
--- a/man/tcurl.1
+++ b/man/tcurl.1
@@ -1,4 +1,4 @@
-.TH "TCURL" "1" "October 2015" "v4.17.0" "tcurl"
+.TH "TCURL" "1" "October 2015" "v4.17.2" "tcurl"
 .SH "NAME"
 \fBtcurl\fR \- curl for tchannel
 .SH SYNOPSIS


### PR DESCRIPTION
this is a fix for issue: https://github.com/uber/tcurl/issues/76
sendRequest is a private method and the interface change form time to time.
forwardToTChannel is a public method that tcurl is supposed to use.

@ShanniLi @kriskowal 