### PR TITLE
Add error for missing Thrift IDL argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -263,6 +263,11 @@ TCurl.prototype.parseJsonArgs = function parseJsonArgs(opts, delegate) {
 
 TCurl.prototype.readThrift = function readThrift(opts, delegate) {
     var self = this;
+    if (opts.thrift === null) {
+        delegate.error('Must specify a thrift file with -t|--thrift for Thrift endpoints');
+        delegate.error('or specify --json for JSON endpoints that contain ::');
+        return null;
+    }
     try {
         return fs.readFileSync(opts.thrift, 'utf8');
     } catch (err) {


### PR DESCRIPTION
tcurl infers as=thrift from :: in an arg1, but still needs a -t for the Thrift IDL file now. We will eventually hit Meta::thriftIDL if we don’t have -t, but this gives us an understandable error for now.

r @ShanniLi @malandrew 