### PR TITLE
Fix raw mode output

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -80,7 +80,7 @@ Logger.prototype.response = function response(res, opts) {
     }
 
     if (opts.raw) {
-        console.log(res);
+        process.stdout.write(res.body);
     } else {
         console.log(JSON.stringify(res));
     }


### PR DESCRIPTION
Previously in raw mode, it would dump the entire response object. This dumps the response body (buffer) directly to stdout.

r @ShanniLi @malandrew 