### PR TITLE
Defer to TChannel for peer selection

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -63,10 +63,9 @@ function Benchmark(options) {
 
 Benchmark.prototype.run = function run(callback) {
     var self = this;
-    self.tcurl.prepare(self.cmdOptions, self.delegate, function send() {
-        self.stopTime = Date.now() + self.time;
-        self.sendLoop(onComplete);
-    });
+    self.tcurl.prepare(self.cmdOptions, self.delegate);
+    self.stopTime = Date.now() + self.time;
+    self.sendLoop(onComplete);
 
     function onComplete() {
         process.nextTick(callback);

--- a/index.js
+++ b/index.js
@@ -325,7 +325,7 @@ TCurl.prototype.readThriftDir = function readThriftDir(opts, delegate) {
     return sources[opts.service];
 };
 
-TCurl.prototype.prepare = function prepare(opts, delegate, callback) {
+TCurl.prototype.prepare = function prepare(opts, delegate) {
     var self = this;
 
     // May report errors for arg2, arg3, or both
@@ -348,19 +348,6 @@ TCurl.prototype.prepare = function prepare(opts, delegate, callback) {
             }
         }
     });
-
-    var peer = self.subChannel.peers.choosePeer();
-    // TODO: the host option should be called peer, hostPort, or address
-    self.client.waitForIdentified({host: peer.hostPort}, onIdentified);
-
-    function onIdentified(err) {
-        if (err) {
-            delegate.error(err);
-            return delegate.exit();
-        }
-
-        callback();
-    }
 };
 
 TCurl.prototype.createRequest = function createRequest(opts) {
@@ -397,14 +384,8 @@ TCurl.prototype.send = function send(opts, request, delegate) {
 
 TCurl.prototype.request = function tcurlRequest(opts, delegate) {
     var self = this;
-    self.prepare(opts, delegate, onReady);
-
-    function onReady() {
-        self.send(opts,
-            self.createRequest(opts),
-            delegate
-        );
-    }
+    self.prepare(opts, delegate);
+    self.send(opts, self.createRequest(opts), delegate);
 };
 
 TCurl.prototype.asThrift = function asThrift(opts, request, delegate, done) {


### PR DESCRIPTION
This gets rid of an unnecessary explicit call to choosePeer, which then necessitates an explicit waitForPeerIdentified. This fixes retries, enabling retries to other members of the peer list.

r @raynos @ShanniLi 