### PR TITLE
Allow optional Thrift arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -437,6 +437,7 @@ TCurl.prototype.asThrift = function asThrift(opts, request, delegate, done) {
     try {
         sender = new TChannelAsThrift({
             entryPoint: entryPoint,
+            allowOptionalArguments: true,
             strict: opts.strict
         });
     } catch (err) {

--- a/man/tcurl.1
+++ b/man/tcurl.1
@@ -1,4 +1,4 @@
-.TH "TCURL" "1" "April 2016" "v4.21.2" "tcurl"
+.TH "TCURL" "1" "May 2016" "v4.21.2" "tcurl"
 .SH "NAME"
 \fBtcurl\fR \- curl for tchannel
 .SH SYNOPSIS

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "readable-stream": "^1.0.33",
     "safe-json-parse": "^4.0.0",
     "shon": "^3.0.5",
-    "tchannel": "^3.6.24",
+    "tchannel": "^3.7.0",
+    "thriftrw": "^3.5.0",
     "traverse": "^0.6.6",
     "xtend": "^4.0.0"
   },

--- a/test/as-thrift.js
+++ b/test/as-thrift.js
@@ -43,7 +43,8 @@ test('getting an ok response', function t(assert) {
     var endpoint = 'Meta::health';
 
     var tchannelAsThrift = TChannelAsThrift({
-        entryPoint: path.join(__dirname, '..', 'meta.thrift')
+        entryPoint: path.join(__dirname, '..', 'meta.thrift'),
+        allowOptionalArguments: true
     });
     tchannelAsThrift.register(server, endpoint, opts, health);
 
@@ -283,7 +284,8 @@ test('use a thrift include', function t(assert) {
     var userName = 'Bob';
 
     var tchannelAsThrift = TChannelAsThrift({
-        entryPoint: path.join(__dirname, 'users.thrift')
+        entryPoint: path.join(__dirname, 'users.thrift'),
+        allowOptionalArguments: true
     });
     tchannelAsThrift.register(server, endpoint, opts, getUser);
 

--- a/test/usersbase.thrift
+++ b/test/usersbase.thrift
@@ -5,5 +5,5 @@ struct User {
 }
 
 service UsersBase {
-    User getUser(1: string name)
+    User getUser(1: optional string name)
 }


### PR DESCRIPTION
This enables optional arguments for tcurl, bringing tcurl into alignment with existing non-Node.js services.