### PR TITLE
Make tcurl work for 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "lts/*"
+  - "0.10"
 script: npm run travis

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,708 +4,490 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://unpm.uberinternal.com/@babel%2fcode-frame/-/code-frame-7.0.0-beta.49.tgz",
-      "integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "7.0.0-beta.49"
-      }
-    },
-    "@babel/generator": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://unpm.uberinternal.com/@babel%2fgenerator/-/generator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-6c/9qROZaszseTu8JauRvBnQv3o=",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.49",
-        "jsesc": "2.5.1",
-        "lodash": "4.17.10",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://unpm.uberinternal.com/@babel%2fhelper-function-name/-/helper-function-name-7.0.0-beta.49.tgz",
-      "integrity": "sha1-olwRGbnwNSeGcBJuAiXAMEHI3jI=",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://unpm.uberinternal.com/@babel%2fhelper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.49.tgz",
-      "integrity": "sha1-z1Aj8y0q2S0Ic3STnOwJUby1FEE=",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.49"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://unpm.uberinternal.com/@babel%2fhelper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.49.tgz",
-      "integrity": "sha1-QNeO2glo0BGxxShm5XRs+yPldUg=",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.49"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://unpm.uberinternal.com/@babel%2fhighlight/-/highlight-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
-      "dev": true,
-      "requires": {
-        "chalk": "2.4.1",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      }
-    },
-    "@babel/parser": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://unpm.uberinternal.com/@babel%2fparser/-/parser-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w=",
-      "dev": true
-    },
-    "@babel/template": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://unpm.uberinternal.com/@babel%2ftemplate/-/template-7.0.0-beta.49.tgz",
-      "integrity": "sha1-44q+ghfLl5P0YaUwbXrXRdg+HSc=",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
-        "lodash": "4.17.10"
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://unpm.uberinternal.com/@babel%2ftraverse/-/traverse-7.0.0-beta.49.tgz",
-      "integrity": "sha1-TypzaCoYM07WYl0QCo0nMZ98LWg=",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "@babel/generator": "7.0.0-beta.49",
-        "@babel/helper-function-name": "7.0.0-beta.49",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
-        "debug": "3.1.0",
-        "globals": "11.5.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.10"
-      }
-    },
-    "@babel/types": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://unpm.uberinternal.com/@babel%2ftypes/-/types-7.0.0-beta.49.tgz",
-      "integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2",
-        "lodash": "4.17.10",
-        "to-fast-properties": "2.0.0"
-      }
-    },
-    "acorn": {
-      "version": "5.6.2",
-      "resolved": "https://unpm.uberinternal.com/acorn/-/acorn-5.6.2.tgz",
-      "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
-      "dev": true
-    },
-    "acorn-jsx": {
-      "version": "3.0.1",
-      "resolved": "https://unpm.uberinternal.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
-      "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "resolved": "https://unpm.uberinternal.com/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
-          "dev": true
-        }
-      }
-    },
-    "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://unpm.uberinternal.com/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
-      }
-    },
-    "ajv-keywords": {
-      "version": "2.1.1",
-      "resolved": "https://unpm.uberinternal.com/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
-      "dev": true
-    },
-    "ansi-align": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/ansi-align/-/ansi-align-1.1.0.tgz",
-      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://unpm.uberinternal.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://unpm.uberinternal.com/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://unpm.uberinternal.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
-      }
-    },
-    "ansi-color": {
-      "version": "0.2.1",
-      "resolved": "https://unpm.uberinternal.com/ansi-color/-/ansi-color-0.2.1.tgz",
-      "integrity": "sha1-PnXAN0dSF1RO12Oo21cJ+prlv5o="
-    },
-    "ansi-escapes": {
-      "version": "3.1.0",
-      "resolved": "https://unpm.uberinternal.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-      "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
-      "dev": true
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://unpm.uberinternal.com/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "2.0.1",
-      "resolved": "https://unpm.uberinternal.com/ansi-styles/-/ansi-styles-2.0.1.tgz",
-      "integrity": "sha1-sDP1f5Pi0oreuLwRE4+hPaD9IKM="
-    },
-    "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://unpm.uberinternal.com/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "1.0.3"
-      }
-    },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://unpm.uberinternal.com/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://unpm.uberinternal.com/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://unpm.uberinternal.com/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "dev": true
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://unpm.uberinternal.com/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://unpm.uberinternal.com/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://unpm.uberinternal.com/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
-      "dev": true
-    },
-    "babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://unpm.uberinternal.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://unpm.uberinternal.com/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://unpm.uberinternal.com/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://unpm.uberinternal.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://unpm.uberinternal.com/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "bindings": {
-      "version": "1.2.1",
-      "resolved": "https://unpm.uberinternal.com/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
-    },
-    "boxen": {
-      "version": "0.6.0",
-      "resolved": "https://unpm.uberinternal.com/boxen/-/boxen-0.6.0.tgz",
-      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
-      "dev": true,
-      "requires": {
-        "ansi-align": "1.1.0",
-        "camelcase": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-boxes": "1.0.0",
-        "filled-array": "1.1.0",
-        "object-assign": "4.1.1",
-        "repeating": "2.0.1",
-        "string-width": "1.0.2",
-        "widest-line": "1.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://unpm.uberinternal.com/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://unpm.uberinternal.com/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://unpm.uberinternal.com/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://unpm.uberinternal.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://unpm.uberinternal.com/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://unpm.uberinternal.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://unpm.uberinternal.com/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://unpm.uberinternal.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "buffer-from": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/buffer-from/-/buffer-from-1.1.0.tgz",
-      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
-      "dev": true
-    },
-    "bufrw": {
-      "version": "1.2.1",
-      "resolved": "https://unpm.uberinternal.com/bufrw/-/bufrw-1.2.1.tgz",
-      "integrity": "sha1-k/IiIptPX14s1VkjaJFAf5hTZjs=",
-      "requires": {
-        "ansi-color": "0.2.1",
-        "error": "7.0.2",
-        "xtend": "4.0.1"
-      }
-    },
-    "bytes": {
-      "version": "3.0.0",
-      "resolved": "https://unpm.uberinternal.com/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
-    },
-    "caller-path": {
-      "version": "0.1.0",
-      "resolved": "https://unpm.uberinternal.com/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "0.2.0"
-      }
-    },
-    "callsites": {
-      "version": "0.2.0",
-      "resolved": "https://unpm.uberinternal.com/callsites/-/callsites-0.2.0.tgz",
-      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
-      "dev": true
-    },
-    "camelcase": {
-      "version": "4.1.0",
-      "resolved": "https://unpm.uberinternal.com/camelcase/-/camelcase-4.1.0.tgz",
-      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-    },
     "camelcase-keys": {
-      "version": "4.2.0",
-      "resolved": "https://unpm.uberinternal.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-      "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
-      "requires": {
-        "camelcase": "4.1.0",
-        "map-obj": "2.0.0",
-        "quick-lru": "1.1.0"
-      }
-    },
-    "capture-stack-trace": {
       "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-      "dev": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://unpm.uberinternal.com/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
-    },
-    "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://unpm.uberinternal.com/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-      "dev": true,
+      "resolved": "https://unpm.uberinternal.com/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+      "integrity": "sha1-vRoRv5sxoc5JNJOpMN4aC69K1+w=",
       "requires": {
-        "ansi-styles": "3.2.1",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "camelcase": "1.2.1",
+        "map-obj": "1.0.1"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://unpm.uberinternal.com/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+        "camelcase": {
+          "version": "1.2.1",
+          "resolved": "https://unpm.uberinternal.com/camelcase/-/camelcase-1.2.1.tgz",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
         },
-        "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://unpm.uberinternal.com/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://unpm.uberinternal.com/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         }
       }
-    },
-    "chardet": {
-      "version": "0.4.2",
-      "resolved": "https://unpm.uberinternal.com/chardet/-/chardet-0.4.2.tgz",
-      "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
-      "dev": true
-    },
-    "circular-json": {
-      "version": "0.3.3",
-      "resolved": "https://unpm.uberinternal.com/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
-      "dev": true
-    },
-    "cli-boxes": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-      "dev": true
-    },
-    "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://unpm.uberinternal.com/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "2.0.0"
-      }
-    },
-    "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://unpm.uberinternal.com/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
-      "dev": true
-    },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://unpm.uberinternal.com/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
-    },
-    "collect-parallel": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/collect-parallel/-/collect-parallel-1.0.1.tgz",
-      "integrity": "sha1-Gxn5KjKQ1L4MkyXqyXwu1l5+0U8=",
-      "requires": {
-        "rezult": "1.1.0"
-      }
-    },
-    "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://unpm.uberinternal.com/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://unpm.uberinternal.com/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://unpm.uberinternal.com/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-      "dev": true,
-      "requires": {
-        "delayed-stream": "1.0.0"
-      }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://unpm.uberinternal.com/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://unpm.uberinternal.com/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
-      "requires": {
-        "buffer-from": "1.1.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6",
-        "typedarray": "0.0.6"
-      }
-    },
-    "configstore": {
-      "version": "2.1.0",
-      "resolved": "https://unpm.uberinternal.com/configstore/-/configstore-2.1.0.tgz",
-      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
-      "dev": true,
-      "requires": {
-        "dot-prop": "3.0.0",
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1",
-        "os-tmpdir": "1.0.2",
-        "osenv": "0.1.5",
-        "uuid": "2.0.3",
-        "write-file-atomic": "1.3.4",
-        "xdg-basedir": "2.0.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://unpm.uberinternal.com/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-          "dev": true
-        }
-      }
-    },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://unpm.uberinternal.com/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "coveralls": {
-      "version": "3.0.1",
-      "resolved": "https://unpm.uberinternal.com/coveralls/-/coveralls-3.0.1.tgz",
-      "integrity": "sha512-FAzXwiDOYLGDWH+zgoIA+8GbWv50hlx+kpEJyvzLKOdnIBv9uWoVl4DhqGgyUHpiRjAlF8KYZSipWXYtllWH6Q==",
+      "version": "3.0.2",
+      "resolved": "https://unpm.uberinternal.com/coveralls/-/coveralls-3.0.2.tgz",
+      "integrity": "sha1-9aC82Qyk5k4Ii3EPqN2mQK6kiE8=",
       "dev": true,
       "requires": {
+        "growl": "1.10.5",
         "js-yaml": "3.12.0",
         "lcov-parse": "0.0.10",
         "log-driver": "1.2.7",
         "minimist": "1.2.0",
         "request": "2.87.0"
-      }
-    },
-    "crc": {
-      "version": "3.2.1",
-      "resolved": "https://unpm.uberinternal.com/crc/-/crc-3.2.1.tgz",
-      "integrity": "sha1-XZyPt3okXNXsopHl0tAFM0urAII="
-    },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://unpm.uberinternal.com/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "1.0.0"
-      }
-    },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://unpm.uberinternal.com/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "4.1.3",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://unpm.uberinternal.com/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://unpm.uberinternal.com/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
-      "requires": {
-        "ms": "2.0.0"
+      },
+      "dependencies": {
+        "growl": {
+          "version": "1.10.5",
+          "resolved": "https://unpm.uberinternal.com/growl/-/growl-1.10.5.tgz",
+          "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.12.0",
+          "resolved": "https://unpm.uberinternal.com/js-yaml/-/js-yaml-3.12.0.tgz",
+          "integrity": "sha1-6u1lbsg0TxD1J8a/obbiJE3hZ9E=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "4.0.0"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.10",
+              "resolved": "https://unpm.uberinternal.com/argparse/-/argparse-1.0.10.tgz",
+              "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+              "dev": true,
+              "requires": {
+                "sprintf-js": "1.0.3"
+              },
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "resolved": "https://unpm.uberinternal.com/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                  "dev": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "4.0.0",
+              "resolved": "https://unpm.uberinternal.com/esprima/-/esprima-4.0.0.tgz",
+              "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ=",
+              "dev": true
+            }
+          }
+        },
+        "lcov-parse": {
+          "version": "0.0.10",
+          "resolved": "https://unpm.uberinternal.com/lcov-parse/-/lcov-parse-0.0.10.tgz",
+          "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+          "dev": true
+        },
+        "log-driver": {
+          "version": "1.2.7",
+          "resolved": "https://unpm.uberinternal.com/log-driver/-/log-driver-1.2.7.tgz",
+          "integrity": "sha1-Y7lQIfBwL+36LJuwok53l9cYcdg=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.87.0",
+          "resolved": "https://unpm.uberinternal.com/request/-/request-2.87.0.tgz",
+          "integrity": "sha1-MvACNc0I1IK00NaNuTqCnA7VdW4=",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.7.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.6",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.2",
+            "har-validator": "5.0.3",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.18",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.2",
+            "tough-cookie": "2.3.4",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
+          },
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.7.0",
+              "resolved": "https://unpm.uberinternal.com/aws-sign2/-/aws-sign2-0.7.0.tgz",
+              "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+              "dev": true
+            },
+            "aws4": {
+              "version": "1.7.0",
+              "resolved": "https://unpm.uberinternal.com/aws4/-/aws4-1.7.0.tgz",
+              "integrity": "sha1-1NDpudv8p3vwjusKikcVUP454ok=",
+              "dev": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "resolved": "https://unpm.uberinternal.com/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+              "dev": true
+            },
+            "combined-stream": {
+              "version": "1.0.6",
+              "resolved": "https://unpm.uberinternal.com/combined-stream/-/combined-stream-1.0.6.tgz",
+              "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+              "dev": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              },
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "resolved": "https://unpm.uberinternal.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+                  "dev": true
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "resolved": "https://unpm.uberinternal.com/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+              "dev": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "resolved": "https://unpm.uberinternal.com/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+              "dev": true
+            },
+            "form-data": {
+              "version": "2.3.2",
+              "resolved": "https://unpm.uberinternal.com/form-data/-/form-data-2.3.2.tgz",
+              "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+              "dev": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.6",
+                "mime-types": "2.1.18"
+              },
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "resolved": "https://unpm.uberinternal.com/asynckit/-/asynckit-0.4.0.tgz",
+                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+                  "dev": true
+                }
+              }
+            },
+            "har-validator": {
+              "version": "5.0.3",
+              "resolved": "https://unpm.uberinternal.com/har-validator/-/har-validator-5.0.3.tgz",
+              "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+              "dev": true,
+              "requires": {
+                "ajv": "5.5.2",
+                "har-schema": "2.0.0"
+              },
+              "dependencies": {
+                "ajv": {
+                  "version": "5.5.2",
+                  "resolved": "https://unpm.uberinternal.com/ajv/-/ajv-5.5.2.tgz",
+                  "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                  "dev": true,
+                  "requires": {
+                    "co": "4.6.0",
+                    "fast-deep-equal": "1.1.0",
+                    "fast-json-stable-stringify": "2.0.0",
+                    "json-schema-traverse": "0.3.1"
+                  },
+                  "dependencies": {
+                    "co": {
+                      "version": "4.6.0",
+                      "resolved": "https://unpm.uberinternal.com/co/-/co-4.6.0.tgz",
+                      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+                      "dev": true
+                    },
+                    "fast-deep-equal": {
+                      "version": "1.1.0",
+                      "resolved": "https://unpm.uberinternal.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+                      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+                      "dev": true
+                    },
+                    "fast-json-stable-stringify": {
+                      "version": "2.0.0",
+                      "resolved": "https://unpm.uberinternal.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+                      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+                      "dev": true
+                    },
+                    "json-schema-traverse": {
+                      "version": "0.3.1",
+                      "resolved": "https://unpm.uberinternal.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+                      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+                      "dev": true
+                    }
+                  }
+                },
+                "har-schema": {
+                  "version": "2.0.0",
+                  "resolved": "https://unpm.uberinternal.com/har-schema/-/har-schema-2.0.0.tgz",
+                  "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+                  "dev": true
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.2.0",
+              "resolved": "https://unpm.uberinternal.com/http-signature/-/http-signature-1.2.0.tgz",
+              "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+              "dev": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "jsprim": "1.4.1",
+                "sshpk": "1.14.2"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "resolved": "https://unpm.uberinternal.com/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                  "dev": true
+                },
+                "jsprim": {
+                  "version": "1.4.1",
+                  "resolved": "https://unpm.uberinternal.com/jsprim/-/jsprim-1.4.1.tgz",
+                  "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+                  "dev": true,
+                  "requires": {
+                    "assert-plus": "1.0.0",
+                    "extsprintf": "1.3.0",
+                    "json-schema": "0.2.3",
+                    "verror": "1.10.0"
+                  },
+                  "dependencies": {
+                    "extsprintf": {
+                      "version": "1.3.0",
+                      "resolved": "https://unpm.uberinternal.com/extsprintf/-/extsprintf-1.3.0.tgz",
+                      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+                      "dev": true
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "resolved": "https://unpm.uberinternal.com/json-schema/-/json-schema-0.2.3.tgz",
+                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+                      "dev": true
+                    },
+                    "verror": {
+                      "version": "1.10.0",
+                      "resolved": "https://unpm.uberinternal.com/verror/-/verror-1.10.0.tgz",
+                      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "extsprintf": "1.3.0"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "resolved": "https://unpm.uberinternal.com/core-util-is/-/core-util-is-1.0.2.tgz",
+                          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.14.2",
+                  "resolved": "https://unpm.uberinternal.com/sshpk/-/sshpk-1.14.2.tgz",
+                  "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+                  "dev": true,
+                  "requires": {
+                    "asn1": "0.2.3",
+                    "assert-plus": "1.0.0",
+                    "bcrypt-pbkdf": "1.0.2",
+                    "dashdash": "1.14.1",
+                    "ecc-jsbn": "0.1.1",
+                    "getpass": "0.1.7",
+                    "jsbn": "0.1.1",
+                    "safer-buffer": "2.1.2",
+                    "tweetnacl": "0.14.5"
+                  },
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "resolved": "https://unpm.uberinternal.com/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+                      "dev": true
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.2",
+                      "resolved": "https://unpm.uberinternal.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+                      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "0.14.5"
+                      }
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "resolved": "https://unpm.uberinternal.com/dashdash/-/dashdash-1.14.1.tgz",
+                      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "resolved": "https://unpm.uberinternal.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.7",
+                      "resolved": "https://unpm.uberinternal.com/getpass/-/getpass-0.1.7.tgz",
+                      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+                      "dev": true,
+                      "requires": {
+                        "assert-plus": "1.0.0"
+                      }
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "resolved": "https://unpm.uberinternal.com/jsbn/-/jsbn-0.1.1.tgz",
+                      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "safer-buffer": {
+                      "version": "2.1.2",
+                      "resolved": "https://unpm.uberinternal.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+                      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+                      "dev": true
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "resolved": "https://unpm.uberinternal.com/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "resolved": "https://unpm.uberinternal.com/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+              "dev": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "resolved": "https://unpm.uberinternal.com/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+              "dev": true
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "resolved": "https://unpm.uberinternal.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+              "dev": true
+            },
+            "mime-types": {
+              "version": "2.1.18",
+              "resolved": "https://unpm.uberinternal.com/mime-types/-/mime-types-2.1.18.tgz",
+              "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
+              "dev": true,
+              "requires": {
+                "mime-db": "1.33.0"
+              },
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.33.0",
+                  "resolved": "https://unpm.uberinternal.com/mime-db/-/mime-db-1.33.0.tgz",
+                  "integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s=",
+                  "dev": true
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "resolved": "https://unpm.uberinternal.com/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+              "dev": true
+            },
+            "performance-now": {
+              "version": "2.1.0",
+              "resolved": "https://unpm.uberinternal.com/performance-now/-/performance-now-2.1.0.tgz",
+              "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+              "dev": true
+            },
+            "qs": {
+              "version": "6.5.2",
+              "resolved": "https://unpm.uberinternal.com/qs/-/qs-6.5.2.tgz",
+              "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+              "dev": true
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://unpm.uberinternal.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+              "dev": true
+            },
+            "tough-cookie": {
+              "version": "2.3.4",
+              "resolved": "https://unpm.uberinternal.com/tough-cookie/-/tough-cookie-2.3.4.tgz",
+              "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
+              "dev": true,
+              "requires": {
+                "punycode": "1.4.1"
+              },
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1",
+                  "resolved": "https://unpm.uberinternal.com/punycode/-/punycode-1.4.1.tgz",
+                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                  "dev": true
+                }
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "resolved": "https://unpm.uberinternal.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+              "dev": true,
+              "requires": {
+                "safe-buffer": "5.1.2"
+              }
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://unpm.uberinternal.com/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "debug-logtron": {
@@ -719,381 +501,1958 @@
         "supports-color": "1.3.1",
         "term-color": "1.0.1",
         "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "collect-parallel": {
+          "version": "1.0.1",
+          "resolved": "https://unpm.uberinternal.com/collect-parallel/-/collect-parallel-1.0.1.tgz",
+          "integrity": "sha1-Gxn5KjKQ1L4MkyXqyXwu1l5+0U8=",
+          "requires": {
+            "rezult": "1.1.0"
+          },
+          "dependencies": {
+            "rezult": {
+              "version": "1.1.0",
+              "resolved": "https://unpm.uberinternal.com/rezult/-/rezult-1.1.0.tgz",
+              "integrity": "sha1-Jymr+VQoe8+6feobp5qU+/8h+2s="
+            }
+          }
+        },
+        "error": {
+          "version": "7.0.2",
+          "resolved": "https://unpm.uberinternal.com/error/-/error-7.0.2.tgz",
+          "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+          "requires": {
+            "string-template": "0.2.1",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "string-template": {
+              "version": "0.2.1",
+              "resolved": "https://unpm.uberinternal.com/string-template/-/string-template-0.2.1.tgz",
+              "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
+            }
+          }
+        },
+        "supports-color": {
+          "version": "1.3.1",
+          "resolved": "https://unpm.uberinternal.com/supports-color/-/supports-color-1.3.1.tgz",
+          "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0="
+        },
+        "term-color": {
+          "version": "1.0.1",
+          "resolved": "https://unpm.uberinternal.com/term-color/-/term-color-1.0.1.tgz",
+          "integrity": "sha1-OOGSVTpHPjXkFgT/UZmEa/gRejo=",
+          "requires": {
+            "ansi-styles": "2.0.1",
+            "supports-color": "1.3.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "resolved": "https://unpm.uberinternal.com/ansi-styles/-/ansi-styles-2.0.1.tgz",
+              "integrity": "sha1-sDP1f5Pi0oreuLwRE4+hPaD9IKM="
+            }
+          }
+        }
       }
-    },
-    "deep-equal": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
-      "dev": true
-    },
-    "deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://unpm.uberinternal.com/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://unpm.uberinternal.com/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "define-properties": {
-      "version": "1.1.2",
-      "resolved": "https://unpm.uberinternal.com/define-properties/-/define-properties-1.1.2.tgz",
-      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      }
-    },
-    "defined": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true
-    },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://unpm.uberinternal.com/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.1",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
-      }
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
-    "depd": {
-      "version": "1.1.2",
-      "resolved": "https://unpm.uberinternal.com/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-    },
-    "doctrine": {
-      "version": "2.1.0",
-      "resolved": "https://unpm.uberinternal.com/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2"
-      }
-    },
-    "dot-prop": {
-      "version": "3.0.0",
-      "resolved": "https://unpm.uberinternal.com/dot-prop/-/dot-prop-3.0.0.tgz",
-      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
-      "dev": true,
-      "requires": {
-        "is-obj": "1.0.1"
-      }
-    },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://unpm.uberinternal.com/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.3.6"
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://unpm.uberinternal.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "jsbn": "0.1.1"
-      }
-    },
-    "error": {
-      "version": "7.0.2",
-      "resolved": "https://unpm.uberinternal.com/error/-/error-7.0.2.tgz",
-      "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
-      "requires": {
-        "string-template": "0.2.1",
-        "xtend": "4.0.1"
-      }
-    },
-    "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://unpm.uberinternal.com/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
-    },
-    "es-abstract": {
-      "version": "1.12.0",
-      "resolved": "https://unpm.uberinternal.com/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.3",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://unpm.uberinternal.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
-      "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://unpm.uberinternal.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
     },
     "eslint": {
-      "version": "4.19.1",
-      "resolved": "https://unpm.uberinternal.com/eslint/-/eslint-4.19.1.tgz",
-      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "version": "1.10.3",
+      "resolved": "https://unpm.uberinternal.com/eslint/-/eslint-1.10.3.tgz",
+      "integrity": "sha1-+xmpGxPBWAgrvKKUsX2Xm8g1Ogo=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.4.1",
+        "chalk": "1.1.3",
         "concat-stream": "1.6.2",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.4",
-        "esquery": "1.0.1",
+        "debug": "2.6.9",
+        "doctrine": "0.7.2",
+        "escape-string-regexp": "1.0.5",
+        "escope": "3.6.0",
+        "espree": "2.2.5",
+        "estraverse": "4.2.0",
+        "estraverse-fb": "1.3.2",
         "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.5.0",
-        "ignore": "3.3.8",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
+        "file-entry-cache": "1.3.1",
+        "glob": "5.0.15",
+        "globals": "8.18.0",
+        "handlebars": "4.0.11",
+        "inquirer": "0.11.4",
+        "is-my-json-valid": "2.17.2",
         "is-resolvable": "1.1.0",
-        "js-yaml": "3.12.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.10",
+        "js-yaml": "3.4.5",
+        "json-stable-stringify": "1.0.1",
+        "lodash.clonedeep": "3.0.2",
+        "lodash.merge": "3.3.2",
+        "lodash.omit": "3.1.0",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
+        "object-assign": "4.1.1",
+        "optionator": "0.6.0",
+        "path-is-absolute": "1.0.1",
         "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "regexpp": "1.1.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
-      }
-    },
-    "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://unpm.uberinternal.com/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "4.2.1",
-        "estraverse": "4.2.0"
-      }
-    },
-    "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
-    },
-    "espree": {
-      "version": "3.5.4",
-      "resolved": "https://unpm.uberinternal.com/espree/-/espree-3.5.4.tgz",
-      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.6.2",
-        "acorn-jsx": "3.0.1"
-      }
-    },
-    "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://unpm.uberinternal.com/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-      "dev": true
-    },
-    "esquery": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/esquery/-/esquery-1.0.1.tgz",
-      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0"
-      }
-    },
-    "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://unpm.uberinternal.com/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0"
-      }
-    },
-    "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://unpm.uberinternal.com/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://unpm.uberinternal.com/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
-    },
-    "events": {
-      "version": "2.1.0",
-      "resolved": "https://unpm.uberinternal.com/events/-/events-2.1.0.tgz",
-      "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg=="
-    },
-    "extend": {
-      "version": "3.0.1",
-      "resolved": "https://unpm.uberinternal.com/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
-      "dev": true
-    },
-    "external-editor": {
-      "version": "2.2.0",
-      "resolved": "https://unpm.uberinternal.com/external-editor/-/external-editor-2.2.0.tgz",
-      "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
-      "dev": true,
-      "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.23",
-        "tmp": "0.0.33"
-      }
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://unpm.uberinternal.com/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
-    },
-    "farmhash": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/farmhash/-/farmhash-1.1.0.tgz",
-      "integrity": "sha1-8Qeb+4JOlg0wSthejfxa+zdA7ZI=",
-      "requires": {
-        "nan": "2.10.0"
-      }
-    },
-    "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-      "dev": true
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://unpm.uberinternal.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
-    },
-    "figures": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
-    },
-    "file-entry-cache": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
-      }
-    },
-    "filled-array": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/filled-array/-/filled-array-1.1.0.tgz",
-      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q=",
-      "dev": true
-    },
-    "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://unpm.uberinternal.com/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-      "dev": true,
-      "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
-      }
-    },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://unpm.uberinternal.com/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
-      "requires": {
-        "is-callable": "1.1.3"
-      }
-    },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://unpm.uberinternal.com/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
-    },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://unpm.uberinternal.com/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "2.3.2",
-      "resolved": "https://unpm.uberinternal.com/form-data/-/form-data-2.3.2.tgz",
-      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-      "dev": true,
-      "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "shelljs": "0.5.3",
+        "strip-json-comments": "1.0.4",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0",
+        "xml-escape": "1.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://unpm.uberinternal.com/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://unpm.uberinternal.com/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "resolved": "https://unpm.uberinternal.com/has-ansi/-/has-ansi-2.0.0.tgz",
+              "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "resolved": "https://unpm.uberinternal.com/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                  "dev": true
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://unpm.uberinternal.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "resolved": "https://unpm.uberinternal.com/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                  "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                  "dev": true
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://unpm.uberinternal.com/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://unpm.uberinternal.com/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+          "dev": true,
+          "requires": {
+            "buffer-from": "1.1.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
+          },
+          "dependencies": {
+            "buffer-from": {
+              "version": "1.1.0",
+              "resolved": "https://unpm.uberinternal.com/buffer-from/-/buffer-from-1.1.0.tgz",
+              "integrity": "sha1-h/yqOimDWOCt5uRCz86EB0DRrQQ=",
+              "dev": true
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://unpm.uberinternal.com/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "resolved": "https://unpm.uberinternal.com/typedarray/-/typedarray-0.0.6.tgz",
+              "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+              "dev": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://unpm.uberinternal.com/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "resolved": "https://unpm.uberinternal.com/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
+            }
+          }
+        },
+        "doctrine": {
+          "version": "0.7.2",
+          "resolved": "https://unpm.uberinternal.com/doctrine/-/doctrine-0.7.2.tgz",
+          "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+          "dev": true,
+          "requires": {
+            "esutils": "1.1.6",
+            "isarray": "0.0.1"
+          },
+          "dependencies": {
+            "esutils": {
+              "version": "1.1.6",
+              "resolved": "https://unpm.uberinternal.com/esutils/-/esutils-1.1.6.tgz",
+              "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U=",
+              "dev": true
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://unpm.uberinternal.com/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "dev": true
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://unpm.uberinternal.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "escope": {
+          "version": "3.6.0",
+          "resolved": "https://unpm.uberinternal.com/escope/-/escope-3.6.0.tgz",
+          "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+          "dev": true,
+          "requires": {
+            "es6-map": "0.1.5",
+            "es6-weak-map": "2.0.2",
+            "esrecurse": "4.2.1",
+            "estraverse": "4.2.0"
+          },
+          "dependencies": {
+            "es6-map": {
+              "version": "0.1.5",
+              "resolved": "https://unpm.uberinternal.com/es6-map/-/es6-map-0.1.5.tgz",
+              "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+              "dev": true,
+              "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.45",
+                "es6-iterator": "2.0.3",
+                "es6-set": "0.1.5",
+                "es6-symbol": "3.1.1",
+                "event-emitter": "0.3.5"
+              },
+              "dependencies": {
+                "d": {
+                  "version": "1.0.0",
+                  "resolved": "https://unpm.uberinternal.com/d/-/d-1.0.0.tgz",
+                  "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+                  "dev": true,
+                  "requires": {
+                    "es5-ext": "0.10.45"
+                  }
+                },
+                "es5-ext": {
+                  "version": "0.10.45",
+                  "resolved": "https://unpm.uberinternal.com/es5-ext/-/es5-ext-0.10.45.tgz",
+                  "integrity": "sha1-C/33tHPaWRnVrfO9Jc63VPzMNlM=",
+                  "dev": true,
+                  "requires": {
+                    "es6-iterator": "2.0.3",
+                    "es6-symbol": "3.1.1",
+                    "next-tick": "1.0.0"
+                  },
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "1.0.0",
+                      "resolved": "https://unpm.uberinternal.com/next-tick/-/next-tick-1.0.0.tgz",
+                      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+                      "dev": true
+                    }
+                  }
+                },
+                "es6-iterator": {
+                  "version": "2.0.3",
+                  "resolved": "https://unpm.uberinternal.com/es6-iterator/-/es6-iterator-2.0.3.tgz",
+                  "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+                  "dev": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.45",
+                    "es6-symbol": "3.1.1"
+                  }
+                },
+                "es6-set": {
+                  "version": "0.1.5",
+                  "resolved": "https://unpm.uberinternal.com/es6-set/-/es6-set-0.1.5.tgz",
+                  "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+                  "dev": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.45",
+                    "es6-iterator": "2.0.3",
+                    "es6-symbol": "3.1.1",
+                    "event-emitter": "0.3.5"
+                  }
+                },
+                "es6-symbol": {
+                  "version": "3.1.1",
+                  "resolved": "https://unpm.uberinternal.com/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                  "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+                  "dev": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.45"
+                  }
+                },
+                "event-emitter": {
+                  "version": "0.3.5",
+                  "resolved": "https://unpm.uberinternal.com/event-emitter/-/event-emitter-0.3.5.tgz",
+                  "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+                  "dev": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.45"
+                  }
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "2.0.2",
+              "resolved": "https://unpm.uberinternal.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+              "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+              "dev": true,
+              "requires": {
+                "d": "1.0.0",
+                "es5-ext": "0.10.45",
+                "es6-iterator": "2.0.3",
+                "es6-symbol": "3.1.1"
+              },
+              "dependencies": {
+                "d": {
+                  "version": "1.0.0",
+                  "resolved": "https://unpm.uberinternal.com/d/-/d-1.0.0.tgz",
+                  "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+                  "dev": true,
+                  "requires": {
+                    "es5-ext": "0.10.45"
+                  }
+                },
+                "es5-ext": {
+                  "version": "0.10.45",
+                  "resolved": "https://unpm.uberinternal.com/es5-ext/-/es5-ext-0.10.45.tgz",
+                  "integrity": "sha1-C/33tHPaWRnVrfO9Jc63VPzMNlM=",
+                  "dev": true,
+                  "requires": {
+                    "es6-iterator": "2.0.3",
+                    "es6-symbol": "3.1.1",
+                    "next-tick": "1.0.0"
+                  },
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "1.0.0",
+                      "resolved": "https://unpm.uberinternal.com/next-tick/-/next-tick-1.0.0.tgz",
+                      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
+                      "dev": true
+                    }
+                  }
+                },
+                "es6-iterator": {
+                  "version": "2.0.3",
+                  "resolved": "https://unpm.uberinternal.com/es6-iterator/-/es6-iterator-2.0.3.tgz",
+                  "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+                  "dev": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.45",
+                    "es6-symbol": "3.1.1"
+                  }
+                },
+                "es6-symbol": {
+                  "version": "3.1.1",
+                  "resolved": "https://unpm.uberinternal.com/es6-symbol/-/es6-symbol-3.1.1.tgz",
+                  "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+                  "dev": true,
+                  "requires": {
+                    "d": "1.0.0",
+                    "es5-ext": "0.10.45"
+                  }
+                }
+              }
+            },
+            "esrecurse": {
+              "version": "4.2.1",
+              "resolved": "https://unpm.uberinternal.com/esrecurse/-/esrecurse-4.2.1.tgz",
+              "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+              "dev": true,
+              "requires": {
+                "estraverse": "4.2.0"
+              }
+            }
+          }
+        },
+        "espree": {
+          "version": "2.2.5",
+          "resolved": "https://unpm.uberinternal.com/espree/-/espree-2.2.5.tgz",
+          "integrity": "sha1-32kbkxCIlAKuspzAZnCMVmkLhUs=",
+          "dev": true
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://unpm.uberinternal.com/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+          "dev": true
+        },
+        "estraverse-fb": {
+          "version": "1.3.2",
+          "resolved": "https://unpm.uberinternal.com/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
+          "integrity": "sha1-0yOky15awzHOoDNBOpJT4WQ+B8Q=",
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "resolved": "https://unpm.uberinternal.com/esutils/-/esutils-2.0.2.tgz",
+          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+          "dev": true
+        },
+        "file-entry-cache": {
+          "version": "1.3.1",
+          "resolved": "https://unpm.uberinternal.com/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+          "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+          "dev": true,
+          "requires": {
+            "flat-cache": "1.3.0",
+            "object-assign": "4.1.1"
+          },
+          "dependencies": {
+            "flat-cache": {
+              "version": "1.3.0",
+              "resolved": "https://unpm.uberinternal.com/flat-cache/-/flat-cache-1.3.0.tgz",
+              "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+              "dev": true,
+              "requires": {
+                "circular-json": "0.3.3",
+                "del": "2.2.2",
+                "graceful-fs": "4.1.11",
+                "write": "0.2.1"
+              },
+              "dependencies": {
+                "circular-json": {
+                  "version": "0.3.3",
+                  "resolved": "https://unpm.uberinternal.com/circular-json/-/circular-json-0.3.3.tgz",
+                  "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+                  "dev": true
+                },
+                "del": {
+                  "version": "2.2.2",
+                  "resolved": "https://unpm.uberinternal.com/del/-/del-2.2.2.tgz",
+                  "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+                  "dev": true,
+                  "requires": {
+                    "globby": "5.0.0",
+                    "is-path-cwd": "1.0.0",
+                    "is-path-in-cwd": "1.0.1",
+                    "object-assign": "4.1.1",
+                    "pify": "2.3.0",
+                    "pinkie-promise": "2.0.1",
+                    "rimraf": "2.6.2"
+                  },
+                  "dependencies": {
+                    "globby": {
+                      "version": "5.0.0",
+                      "resolved": "https://unpm.uberinternal.com/globby/-/globby-5.0.0.tgz",
+                      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+                      "dev": true,
+                      "requires": {
+                        "array-union": "1.0.2",
+                        "arrify": "1.0.1",
+                        "glob": "7.1.2",
+                        "object-assign": "4.1.1",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                      },
+                      "dependencies": {
+                        "array-union": {
+                          "version": "1.0.2",
+                          "resolved": "https://unpm.uberinternal.com/array-union/-/array-union-1.0.2.tgz",
+                          "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                          "dev": true,
+                          "requires": {
+                            "array-uniq": "1.0.3"
+                          },
+                          "dependencies": {
+                            "array-uniq": {
+                              "version": "1.0.3",
+                              "resolved": "https://unpm.uberinternal.com/array-uniq/-/array-uniq-1.0.3.tgz",
+                              "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "arrify": {
+                          "version": "1.0.1",
+                          "resolved": "https://unpm.uberinternal.com/arrify/-/arrify-1.0.1.tgz",
+                          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+                          "dev": true
+                        },
+                        "glob": {
+                          "version": "7.1.2",
+                          "resolved": "https://unpm.uberinternal.com/glob/-/glob-7.1.2.tgz",
+                          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+                          "dev": true,
+                          "requires": {
+                            "fs.realpath": "1.0.0",
+                            "inflight": "1.0.6",
+                            "inherits": "2.0.3",
+                            "minimatch": "3.0.4",
+                            "once": "1.4.0",
+                            "path-is-absolute": "1.0.1"
+                          },
+                          "dependencies": {
+                            "fs.realpath": {
+                              "version": "1.0.0",
+                              "resolved": "https://unpm.uberinternal.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                              "dev": true
+                            },
+                            "inflight": {
+                              "version": "1.0.6",
+                              "resolved": "https://unpm.uberinternal.com/inflight/-/inflight-1.0.6.tgz",
+                              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                              "dev": true,
+                              "requires": {
+                                "once": "1.4.0",
+                                "wrappy": "1.0.2"
+                              },
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://unpm.uberinternal.com/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "resolved": "https://unpm.uberinternal.com/inherits/-/inherits-2.0.3.tgz",
+                              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                              "dev": true
+                            },
+                            "once": {
+                              "version": "1.4.0",
+                              "resolved": "https://unpm.uberinternal.com/once/-/once-1.4.0.tgz",
+                              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                              "dev": true,
+                              "requires": {
+                                "wrappy": "1.0.2"
+                              },
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://unpm.uberinternal.com/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "is-path-cwd": {
+                      "version": "1.0.0",
+                      "resolved": "https://unpm.uberinternal.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+                      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+                      "dev": true
+                    },
+                    "is-path-in-cwd": {
+                      "version": "1.0.1",
+                      "resolved": "https://unpm.uberinternal.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+                      "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
+                      "dev": true,
+                      "requires": {
+                        "is-path-inside": "1.0.1"
+                      },
+                      "dependencies": {
+                        "is-path-inside": {
+                          "version": "1.0.1",
+                          "resolved": "https://unpm.uberinternal.com/is-path-inside/-/is-path-inside-1.0.1.tgz",
+                          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+                          "dev": true,
+                          "requires": {
+                            "path-is-inside": "1.0.2"
+                          }
+                        }
+                      }
+                    },
+                    "pify": {
+                      "version": "2.3.0",
+                      "resolved": "https://unpm.uberinternal.com/pify/-/pify-2.3.0.tgz",
+                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                      "dev": true
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "resolved": "https://unpm.uberinternal.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "dev": true,
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "resolved": "https://unpm.uberinternal.com/pinkie/-/pinkie-2.0.4.tgz",
+                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.6.2",
+                      "resolved": "https://unpm.uberinternal.com/rimraf/-/rimraf-2.6.2.tgz",
+                      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+                      "dev": true,
+                      "requires": {
+                        "glob": "7.1.2"
+                      },
+                      "dependencies": {
+                        "glob": {
+                          "version": "7.1.2",
+                          "resolved": "https://unpm.uberinternal.com/glob/-/glob-7.1.2.tgz",
+                          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+                          "dev": true,
+                          "requires": {
+                            "fs.realpath": "1.0.0",
+                            "inflight": "1.0.6",
+                            "inherits": "2.0.3",
+                            "minimatch": "3.0.4",
+                            "once": "1.4.0",
+                            "path-is-absolute": "1.0.1"
+                          },
+                          "dependencies": {
+                            "fs.realpath": {
+                              "version": "1.0.0",
+                              "resolved": "https://unpm.uberinternal.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+                              "dev": true
+                            },
+                            "inflight": {
+                              "version": "1.0.6",
+                              "resolved": "https://unpm.uberinternal.com/inflight/-/inflight-1.0.6.tgz",
+                              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+                              "dev": true,
+                              "requires": {
+                                "once": "1.4.0",
+                                "wrappy": "1.0.2"
+                              },
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://unpm.uberinternal.com/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "resolved": "https://unpm.uberinternal.com/inherits/-/inherits-2.0.3.tgz",
+                              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                              "dev": true
+                            },
+                            "once": {
+                              "version": "1.4.0",
+                              "resolved": "https://unpm.uberinternal.com/once/-/once-1.4.0.tgz",
+                              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                              "dev": true,
+                              "requires": {
+                                "wrappy": "1.0.2"
+                              },
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.2",
+                                  "resolved": "https://unpm.uberinternal.com/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "resolved": "https://unpm.uberinternal.com/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                  "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                  "dev": true
+                },
+                "write": {
+                  "version": "0.2.1",
+                  "resolved": "https://unpm.uberinternal.com/write/-/write-0.2.1.tgz",
+                  "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+                  "dev": true,
+                  "requires": {
+                    "mkdirp": "0.5.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://unpm.uberinternal.com/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          },
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.6",
+              "resolved": "https://unpm.uberinternal.com/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "dev": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "https://unpm.uberinternal.com/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://unpm.uberinternal.com/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "https://unpm.uberinternal.com/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "https://unpm.uberinternal.com/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "globals": {
+          "version": "8.18.0",
+          "resolved": "https://unpm.uberinternal.com/globals/-/globals-8.18.0.tgz",
+          "integrity": "sha1-k9SmK9ysOM+vr8R9awNHaMsP/LQ=",
+          "dev": true
+        },
+        "handlebars": {
+          "version": "4.0.11",
+          "resolved": "https://unpm.uberinternal.com/handlebars/-/handlebars-4.0.11.tgz",
+          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+          "dev": true,
+          "requires": {
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "resolved": "https://unpm.uberinternal.com/async/-/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "dev": true
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "resolved": "https://unpm.uberinternal.com/optimist/-/optimist-0.6.1.tgz",
+              "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+              "dev": true,
+              "requires": {
+                "minimist": "0.0.10",
+                "wordwrap": "0.0.3"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-0.0.10.tgz",
+                  "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                  "dev": true
+                },
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "resolved": "https://unpm.uberinternal.com/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                  "dev": true
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.4",
+              "resolved": "https://unpm.uberinternal.com/source-map/-/source-map-0.4.4.tgz",
+              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+              "dev": true,
+              "requires": {
+                "amdefine": "1.0.1"
+              },
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.1",
+                  "resolved": "https://unpm.uberinternal.com/amdefine/-/amdefine-1.0.1.tgz",
+                  "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+                  "dev": true
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "resolved": "https://unpm.uberinternal.com/uglify-js/-/uglify-js-2.8.29.tgz",
+              "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "source-map": "0.5.7",
+                "uglify-to-browserify": "1.0.2",
+                "yargs": "3.10.0"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.5.7",
+                  "resolved": "https://unpm.uberinternal.com/source-map/-/source-map-0.5.7.tgz",
+                  "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                  "dev": true,
+                  "optional": true
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "resolved": "https://unpm.uberinternal.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                  "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+                  "dev": true,
+                  "optional": true
+                },
+                "yargs": {
+                  "version": "3.10.0",
+                  "resolved": "https://unpm.uberinternal.com/yargs/-/yargs-3.10.0.tgz",
+                  "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "1.2.1",
+                    "cliui": "2.1.0",
+                    "decamelize": "1.2.0",
+                    "window-size": "0.1.0"
+                  },
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.2.1",
+                      "resolved": "https://unpm.uberinternal.com/camelcase/-/camelcase-1.2.1.tgz",
+                      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "cliui": {
+                      "version": "2.1.0",
+                      "resolved": "https://unpm.uberinternal.com/cliui/-/cliui-2.1.0.tgz",
+                      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "center-align": "0.1.3",
+                        "right-align": "0.1.3",
+                        "wordwrap": "0.0.2"
+                      },
+                      "dependencies": {
+                        "center-align": {
+                          "version": "0.1.3",
+                          "resolved": "https://unpm.uberinternal.com/center-align/-/center-align-0.1.3.tgz",
+                          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "align-text": "0.1.4",
+                            "lazy-cache": "1.0.4"
+                          },
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "resolved": "https://unpm.uberinternal.com/align-text/-/align-text-0.1.4.tgz",
+                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "kind-of": "3.2.2",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.6.1"
+                              },
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.2.2",
+                                  "resolved": "https://unpm.uberinternal.com/kind-of/-/kind-of-3.2.2.tgz",
+                                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "is-buffer": "1.1.6"
+                                  },
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.6",
+                                      "resolved": "https://unpm.uberinternal.com/is-buffer/-/is-buffer-1.1.6.tgz",
+                                      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://unpm.uberinternal.com/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "resolved": "https://unpm.uberinternal.com/repeat-string/-/repeat-string-1.6.1.tgz",
+                                  "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            },
+                            "lazy-cache": {
+                              "version": "1.0.4",
+                              "resolved": "https://unpm.uberinternal.com/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                              "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "right-align": {
+                          "version": "0.1.3",
+                          "resolved": "https://unpm.uberinternal.com/right-align/-/right-align-0.1.3.tgz",
+                          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "align-text": "0.1.4"
+                          },
+                          "dependencies": {
+                            "align-text": {
+                              "version": "0.1.4",
+                              "resolved": "https://unpm.uberinternal.com/align-text/-/align-text-0.1.4.tgz",
+                              "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "kind-of": "3.2.2",
+                                "longest": "1.0.1",
+                                "repeat-string": "1.6.1"
+                              },
+                              "dependencies": {
+                                "kind-of": {
+                                  "version": "3.2.2",
+                                  "resolved": "https://unpm.uberinternal.com/kind-of/-/kind-of-3.2.2.tgz",
+                                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "is-buffer": "1.1.6"
+                                  },
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.6",
+                                      "resolved": "https://unpm.uberinternal.com/is-buffer/-/is-buffer-1.1.6.tgz",
+                                      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "longest": {
+                                  "version": "1.0.1",
+                                  "resolved": "https://unpm.uberinternal.com/longest/-/longest-1.0.1.tgz",
+                                  "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                  "dev": true,
+                                  "optional": true
+                                },
+                                "repeat-string": {
+                                  "version": "1.6.1",
+                                  "resolved": "https://unpm.uberinternal.com/repeat-string/-/repeat-string-1.6.1.tgz",
+                                  "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "wordwrap": {
+                          "version": "0.0.2",
+                          "resolved": "https://unpm.uberinternal.com/wordwrap/-/wordwrap-0.0.2.tgz",
+                          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    },
+                    "decamelize": {
+                      "version": "1.2.0",
+                      "resolved": "https://unpm.uberinternal.com/decamelize/-/decamelize-1.2.0.tgz",
+                      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "resolved": "https://unpm.uberinternal.com/window-size/-/window-size-0.1.0.tgz",
+                      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.11.4",
+          "resolved": "https://unpm.uberinternal.com/inquirer/-/inquirer-0.11.4.tgz",
+          "integrity": "sha1-geM3ToNhvq/y2XAWIG01nQsy+k0=",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "1.1.1",
+            "figures": "1.7.0",
+            "lodash": "3.10.1",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.4.0",
+              "resolved": "https://unpm.uberinternal.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+              "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+              "dev": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "resolved": "https://unpm.uberinternal.com/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+              "dev": true
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "resolved": "https://unpm.uberinternal.com/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+              "dev": true,
+              "requires": {
+                "restore-cursor": "1.0.1"
+              },
+              "dependencies": {
+                "restore-cursor": {
+                  "version": "1.0.1",
+                  "resolved": "https://unpm.uberinternal.com/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                  "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+                  "dev": true,
+                  "requires": {
+                    "exit-hook": "1.1.1",
+                    "onetime": "1.1.0"
+                  },
+                  "dependencies": {
+                    "exit-hook": {
+                      "version": "1.1.1",
+                      "resolved": "https://unpm.uberinternal.com/exit-hook/-/exit-hook-1.1.1.tgz",
+                      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+                      "dev": true
+                    },
+                    "onetime": {
+                      "version": "1.1.0",
+                      "resolved": "https://unpm.uberinternal.com/onetime/-/onetime-1.1.0.tgz",
+                      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "cli-width": {
+              "version": "1.1.1",
+              "resolved": "https://unpm.uberinternal.com/cli-width/-/cli-width-1.1.1.tgz",
+              "integrity": "sha1-pNKT72frt7iNSk1CwMzwDE0eNm0=",
+              "dev": true
+            },
+            "figures": {
+              "version": "1.7.0",
+              "resolved": "https://unpm.uberinternal.com/figures/-/figures-1.7.0.tgz",
+              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+              "dev": true,
+              "requires": {
+                "escape-string-regexp": "1.0.5",
+                "object-assign": "4.1.1"
+              }
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "resolved": "https://unpm.uberinternal.com/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+              "dev": true
+            },
+            "readline2": {
+              "version": "1.0.1",
+              "resolved": "https://unpm.uberinternal.com/readline2/-/readline2-1.0.1.tgz",
+              "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "mute-stream": "0.0.5"
+              },
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "resolved": "https://unpm.uberinternal.com/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                  "dev": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "resolved": "https://unpm.uberinternal.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "resolved": "https://unpm.uberinternal.com/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "resolved": "https://unpm.uberinternal.com/mute-stream/-/mute-stream-0.0.5.tgz",
+                  "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+                  "dev": true
+                }
+              }
+            },
+            "run-async": {
+              "version": "0.1.0",
+              "resolved": "https://unpm.uberinternal.com/run-async/-/run-async-0.1.0.tgz",
+              "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+              "dev": true,
+              "requires": {
+                "once": "1.4.0"
+              },
+              "dependencies": {
+                "once": {
+                  "version": "1.4.0",
+                  "resolved": "https://unpm.uberinternal.com/once/-/once-1.4.0.tgz",
+                  "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                  "dev": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "resolved": "https://unpm.uberinternal.com/wrappy/-/wrappy-1.0.2.tgz",
+                      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "rx-lite": {
+              "version": "3.1.2",
+              "resolved": "https://unpm.uberinternal.com/rx-lite/-/rx-lite-3.1.2.tgz",
+              "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://unpm.uberinternal.com/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "resolved": "https://unpm.uberinternal.com/code-point-at/-/code-point-at-1.1.0.tgz",
+                  "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                  "dev": true
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "resolved": "https://unpm.uberinternal.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.1"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "resolved": "https://unpm.uberinternal.com/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://unpm.uberinternal.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "through": {
+              "version": "2.3.8",
+              "resolved": "https://unpm.uberinternal.com/through/-/through-2.3.8.tgz",
+              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+              "dev": true
+            }
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.17.2",
+          "resolved": "https://unpm.uberinternal.com/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+          "integrity": "sha1-ayEDoojpTvPeXPFdKd2F/Et41lw=",
+          "dev": true,
+          "requires": {
+            "generate-function": "2.0.0",
+            "generate-object-property": "1.2.0",
+            "is-my-ip-valid": "1.0.0",
+            "jsonpointer": "4.0.1",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "generate-function": {
+              "version": "2.0.0",
+              "resolved": "https://unpm.uberinternal.com/generate-function/-/generate-function-2.0.0.tgz",
+              "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+              "dev": true
+            },
+            "generate-object-property": {
+              "version": "1.2.0",
+              "resolved": "https://unpm.uberinternal.com/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+              "dev": true,
+              "requires": {
+                "is-property": "1.0.2"
+              },
+              "dependencies": {
+                "is-property": {
+                  "version": "1.0.2",
+                  "resolved": "https://unpm.uberinternal.com/is-property/-/is-property-1.0.2.tgz",
+                  "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+                  "dev": true
+                }
+              }
+            },
+            "is-my-ip-valid": {
+              "version": "1.0.0",
+              "resolved": "https://unpm.uberinternal.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+              "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
+              "dev": true
+            },
+            "jsonpointer": {
+              "version": "4.0.1",
+              "resolved": "https://unpm.uberinternal.com/jsonpointer/-/jsonpointer-4.0.1.tgz",
+              "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+              "dev": true
+            }
+          }
+        },
+        "is-resolvable": {
+          "version": "1.1.0",
+          "resolved": "https://unpm.uberinternal.com/is-resolvable/-/is-resolvable-1.1.0.tgz",
+          "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.4.5",
+          "resolved": "https://unpm.uberinternal.com/js-yaml/-/js-yaml-3.4.5.tgz",
+          "integrity": "sha1-w0A3l98SuRhmV08t4jZG/oyvtE0=",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.10",
+            "esprima": "2.7.3"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.10",
+              "resolved": "https://unpm.uberinternal.com/argparse/-/argparse-1.0.10.tgz",
+              "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+              "dev": true,
+              "requires": {
+                "sprintf-js": "1.0.3"
+              },
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "resolved": "https://unpm.uberinternal.com/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                  "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                  "dev": true
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.3",
+              "resolved": "https://unpm.uberinternal.com/esprima/-/esprima-2.7.3.tgz",
+              "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+              "dev": true
+            }
+          }
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "resolved": "https://unpm.uberinternal.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+          "dev": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          },
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "resolved": "https://unpm.uberinternal.com/jsonify/-/jsonify-0.0.0.tgz",
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+              "dev": true
+            }
+          }
+        },
+        "lodash.clonedeep": {
+          "version": "3.0.2",
+          "resolved": "https://unpm.uberinternal.com/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
+          "integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
+          "dev": true,
+          "requires": {
+            "lodash._baseclone": "3.3.0",
+            "lodash._bindcallback": "3.0.1"
+          },
+          "dependencies": {
+            "lodash._baseclone": {
+              "version": "3.3.0",
+              "resolved": "https://unpm.uberinternal.com/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
+              "integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
+              "dev": true,
+              "requires": {
+                "lodash._arraycopy": "3.0.0",
+                "lodash._arrayeach": "3.0.0",
+                "lodash._baseassign": "3.2.0",
+                "lodash._basefor": "3.0.3",
+                "lodash.isarray": "3.0.4",
+                "lodash.keys": "3.1.2"
+              },
+              "dependencies": {
+                "lodash._arraycopy": {
+                  "version": "3.0.0",
+                  "resolved": "https://unpm.uberinternal.com/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+                  "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+                  "dev": true
+                },
+                "lodash._arrayeach": {
+                  "version": "3.0.0",
+                  "resolved": "https://unpm.uberinternal.com/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+                  "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+                  "dev": true
+                },
+                "lodash._baseassign": {
+                  "version": "3.2.0",
+                  "resolved": "https://unpm.uberinternal.com/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._basecopy": "3.0.1",
+                    "lodash.keys": "3.1.2"
+                  },
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "resolved": "https://unpm.uberinternal.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                      "dev": true
+                    }
+                  }
+                },
+                "lodash._basefor": {
+                  "version": "3.0.3",
+                  "resolved": "https://unpm.uberinternal.com/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+                  "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+                  "dev": true
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "https://unpm.uberinternal.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                  "dev": true
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "resolved": "https://unpm.uberinternal.com/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._getnative": "3.9.1",
+                    "lodash.isarguments": "3.1.0",
+                    "lodash.isarray": "3.0.4"
+                  },
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "https://unpm.uberinternal.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                      "dev": true
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "resolved": "https://unpm.uberinternal.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "resolved": "https://unpm.uberinternal.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+              "dev": true
+            }
+          }
+        },
+        "lodash.merge": {
+          "version": "3.3.2",
+          "resolved": "https://unpm.uberinternal.com/lodash.merge/-/lodash.merge-3.3.2.tgz",
+          "integrity": "sha1-DZDZPtY3sYeEN7s+IWASYNev6ZQ=",
+          "dev": true,
+          "requires": {
+            "lodash._arraycopy": "3.0.0",
+            "lodash._arrayeach": "3.0.0",
+            "lodash._createassigner": "3.1.1",
+            "lodash._getnative": "3.9.1",
+            "lodash.isarguments": "3.1.0",
+            "lodash.isarray": "3.0.4",
+            "lodash.isplainobject": "3.2.0",
+            "lodash.istypedarray": "3.0.6",
+            "lodash.keys": "3.1.2",
+            "lodash.keysin": "3.0.8",
+            "lodash.toplainobject": "3.0.0"
+          },
+          "dependencies": {
+            "lodash._arraycopy": {
+              "version": "3.0.0",
+              "resolved": "https://unpm.uberinternal.com/lodash._arraycopy/-/lodash._arraycopy-3.0.0.tgz",
+              "integrity": "sha1-due3wfH7klRzdIeKVi7Qaj5Q9uE=",
+              "dev": true
+            },
+            "lodash._arrayeach": {
+              "version": "3.0.0",
+              "resolved": "https://unpm.uberinternal.com/lodash._arrayeach/-/lodash._arrayeach-3.0.0.tgz",
+              "integrity": "sha1-urFWsqkNPxu9XGU0AzSeXlkz754=",
+              "dev": true
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "resolved": "https://unpm.uberinternal.com/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+              "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+              "dev": true,
+              "requires": {
+                "lodash._bindcallback": "3.0.1",
+                "lodash._isiterateecall": "3.0.9",
+                "lodash.restparam": "3.6.1"
+              },
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "resolved": "https://unpm.uberinternal.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+                  "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+                  "dev": true
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "resolved": "https://unpm.uberinternal.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                  "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+                  "dev": true
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "resolved": "https://unpm.uberinternal.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                  "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash._getnative": {
+              "version": "3.9.1",
+              "resolved": "https://unpm.uberinternal.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+              "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+              "dev": true
+            },
+            "lodash.isarguments": {
+              "version": "3.1.0",
+              "resolved": "https://unpm.uberinternal.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+              "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+              "dev": true
+            },
+            "lodash.isarray": {
+              "version": "3.0.4",
+              "resolved": "https://unpm.uberinternal.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+              "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+              "dev": true
+            },
+            "lodash.isplainobject": {
+              "version": "3.2.0",
+              "resolved": "https://unpm.uberinternal.com/lodash.isplainobject/-/lodash.isplainobject-3.2.0.tgz",
+              "integrity": "sha1-moI4rhayAEMpYM1zRlEtASP79MU=",
+              "dev": true,
+              "requires": {
+                "lodash._basefor": "3.0.3",
+                "lodash.isarguments": "3.1.0",
+                "lodash.keysin": "3.0.8"
+              },
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.3",
+                  "resolved": "https://unpm.uberinternal.com/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+                  "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash.istypedarray": {
+              "version": "3.0.6",
+              "resolved": "https://unpm.uberinternal.com/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+              "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I=",
+              "dev": true
+            },
+            "lodash.keys": {
+              "version": "3.1.2",
+              "resolved": "https://unpm.uberinternal.com/lodash.keys/-/lodash.keys-3.1.2.tgz",
+              "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+              "dev": true,
+              "requires": {
+                "lodash._getnative": "3.9.1",
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+              }
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "resolved": "https://unpm.uberinternal.com/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+              "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+              "dev": true,
+              "requires": {
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+              }
+            },
+            "lodash.toplainobject": {
+              "version": "3.0.0",
+              "resolved": "https://unpm.uberinternal.com/lodash.toplainobject/-/lodash.toplainobject-3.0.0.tgz",
+              "integrity": "sha1-KHkK2ULSk9eKpmOgfs9/UsoEGY0=",
+              "dev": true,
+              "requires": {
+                "lodash._basecopy": "3.0.1",
+                "lodash.keysin": "3.0.8"
+              },
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "resolved": "https://unpm.uberinternal.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                  "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "lodash.omit": {
+          "version": "3.1.0",
+          "resolved": "https://unpm.uberinternal.com/lodash.omit/-/lodash.omit-3.1.0.tgz",
+          "integrity": "sha1-iX/jguZBPZrJfGH3jtHgV6AK+fM=",
+          "dev": true,
+          "requires": {
+            "lodash._arraymap": "3.0.0",
+            "lodash._basedifference": "3.0.3",
+            "lodash._baseflatten": "3.1.4",
+            "lodash._bindcallback": "3.0.1",
+            "lodash._pickbyarray": "3.0.2",
+            "lodash._pickbycallback": "3.0.0",
+            "lodash.keysin": "3.0.8",
+            "lodash.restparam": "3.6.1"
+          },
+          "dependencies": {
+            "lodash._arraymap": {
+              "version": "3.0.0",
+              "resolved": "https://unpm.uberinternal.com/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz",
+              "integrity": "sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=",
+              "dev": true
+            },
+            "lodash._basedifference": {
+              "version": "3.0.3",
+              "resolved": "https://unpm.uberinternal.com/lodash._basedifference/-/lodash._basedifference-3.0.3.tgz",
+              "integrity": "sha1-8sIEKWwqeOArOJCBtu3KyTPPYpw=",
+              "dev": true,
+              "requires": {
+                "lodash._baseindexof": "3.1.0",
+                "lodash._cacheindexof": "3.0.2",
+                "lodash._createcache": "3.1.2"
+              },
+              "dependencies": {
+                "lodash._baseindexof": {
+                  "version": "3.1.0",
+                  "resolved": "https://unpm.uberinternal.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
+                  "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
+                  "dev": true
+                },
+                "lodash._cacheindexof": {
+                  "version": "3.0.2",
+                  "resolved": "https://unpm.uberinternal.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
+                  "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
+                  "dev": true
+                },
+                "lodash._createcache": {
+                  "version": "3.1.2",
+                  "resolved": "https://unpm.uberinternal.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
+                  "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+                  "dev": true,
+                  "requires": {
+                    "lodash._getnative": "3.9.1"
+                  },
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "resolved": "https://unpm.uberinternal.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._baseflatten": {
+              "version": "3.1.4",
+              "resolved": "https://unpm.uberinternal.com/lodash._baseflatten/-/lodash._baseflatten-3.1.4.tgz",
+              "integrity": "sha1-B3D/gBMa9uNPO1EXlqe6UhTmX/c=",
+              "dev": true,
+              "requires": {
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+              },
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.1.0",
+                  "resolved": "https://unpm.uberinternal.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                  "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                  "dev": true
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "https://unpm.uberinternal.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash._bindcallback": {
+              "version": "3.0.1",
+              "resolved": "https://unpm.uberinternal.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+              "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
+              "dev": true
+            },
+            "lodash._pickbyarray": {
+              "version": "3.0.2",
+              "resolved": "https://unpm.uberinternal.com/lodash._pickbyarray/-/lodash._pickbyarray-3.0.2.tgz",
+              "integrity": "sha1-H4mNlgfrVgsOFnOEt3x8bRCKpMU=",
+              "dev": true
+            },
+            "lodash._pickbycallback": {
+              "version": "3.0.0",
+              "resolved": "https://unpm.uberinternal.com/lodash._pickbycallback/-/lodash._pickbycallback-3.0.0.tgz",
+              "integrity": "sha1-/2G5oBens699MObFPeKK+hm4dQo=",
+              "dev": true,
+              "requires": {
+                "lodash._basefor": "3.0.3",
+                "lodash.keysin": "3.0.8"
+              },
+              "dependencies": {
+                "lodash._basefor": {
+                  "version": "3.0.3",
+                  "resolved": "https://unpm.uberinternal.com/lodash._basefor/-/lodash._basefor-3.0.3.tgz",
+                  "integrity": "sha1-dVC06SGO8J+tJDQ7YSAhx5tMIMI=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash.keysin": {
+              "version": "3.0.8",
+              "resolved": "https://unpm.uberinternal.com/lodash.keysin/-/lodash.keysin-3.0.8.tgz",
+              "integrity": "sha1-IsRJPrvtsUJ5YqVLRFssinZ/tH8=",
+              "dev": true,
+              "requires": {
+                "lodash.isarguments": "3.1.0",
+                "lodash.isarray": "3.0.4"
+              },
+              "dependencies": {
+                "lodash.isarguments": {
+                  "version": "3.1.0",
+                  "resolved": "https://unpm.uberinternal.com/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                  "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+                  "dev": true
+                },
+                "lodash.isarray": {
+                  "version": "3.0.4",
+                  "resolved": "https://unpm.uberinternal.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                  "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+                  "dev": true
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "resolved": "https://unpm.uberinternal.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+              "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+              "dev": true
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://unpm.uberinternal.com/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.11"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.11",
+              "resolved": "https://unpm.uberinternal.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
+              "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+              "dev": true,
+              "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+              },
+              "dependencies": {
+                "balanced-match": {
+                  "version": "1.0.0",
+                  "resolved": "https://unpm.uberinternal.com/balanced-match/-/balanced-match-1.0.0.tgz",
+                  "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                  "dev": true
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "resolved": "https://unpm.uberinternal.com/concat-map/-/concat-map-0.0.1.tgz",
+                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://unpm.uberinternal.com/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://unpm.uberinternal.com/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
+        "optionator": {
+          "version": "0.6.0",
+          "resolved": "https://unpm.uberinternal.com/optionator/-/optionator-0.6.0.tgz",
+          "integrity": "sha1-tj7Lvw4xX61LyYJ7Rdx7pFKE/LY=",
+          "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "1.0.7",
+            "levn": "0.2.5",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "0.0.3"
+          },
+          "dependencies": {
+            "deep-is": {
+              "version": "0.1.3",
+              "resolved": "https://unpm.uberinternal.com/deep-is/-/deep-is-0.1.3.tgz",
+              "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+              "dev": true
+            },
+            "fast-levenshtein": {
+              "version": "1.0.7",
+              "resolved": "https://unpm.uberinternal.com/fast-levenshtein/-/fast-levenshtein-1.0.7.tgz",
+              "integrity": "sha1-AXjc3uAjuSkFGTrwlZ6KdjnP3Lk=",
+              "dev": true
+            },
+            "levn": {
+              "version": "0.2.5",
+              "resolved": "https://unpm.uberinternal.com/levn/-/levn-0.2.5.tgz",
+              "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
+              "dev": true,
+              "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+              }
+            },
+            "prelude-ls": {
+              "version": "1.1.2",
+              "resolved": "https://unpm.uberinternal.com/prelude-ls/-/prelude-ls-1.1.2.tgz",
+              "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+              "dev": true
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "resolved": "https://unpm.uberinternal.com/type-check/-/type-check-0.3.2.tgz",
+              "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+              "dev": true,
+              "requires": {
+                "prelude-ls": "1.1.2"
+              }
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "resolved": "https://unpm.uberinternal.com/wordwrap/-/wordwrap-0.0.3.tgz",
+              "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+              "dev": true
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "resolved": "https://unpm.uberinternal.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "dev": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "resolved": "https://unpm.uberinternal.com/path-is-inside/-/path-is-inside-1.0.2.tgz",
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "0.5.3",
+          "resolved": "https://unpm.uberinternal.com/shelljs/-/shelljs-0.5.3.tgz",
+          "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://unpm.uberinternal.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "resolved": "https://unpm.uberinternal.com/text-table/-/text-table-0.2.0.tgz",
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+          "dev": true
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "resolved": "https://unpm.uberinternal.com/user-home/-/user-home-2.0.0.tgz",
+          "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+          "dev": true,
+          "requires": {
+            "os-homedir": "1.0.2"
+          },
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2",
+              "resolved": "https://unpm.uberinternal.com/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+              "dev": true
+            }
+          }
+        },
+        "xml-escape": {
+          "version": "1.0.0",
+          "resolved": "https://unpm.uberinternal.com/xml-escape/-/xml-escape-1.0.0.tgz",
+          "integrity": "sha1-AJY9aXsq3wwYXE4E5zF0upsojrI=",
+          "dev": true
+        }
       }
     },
     "format-stack": {
@@ -1114,415 +2473,41 @@
           "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
           "dev": true
         },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
         "process": {
           "version": "0.10.1",
           "resolved": "https://unpm.uberinternal.com/process/-/process-0.10.1.tgz",
           "integrity": "sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=",
           "dev": true
+        },
+        "trycatch": {
+          "version": "1.5.11",
+          "resolved": "https://unpm.uberinternal.com/trycatch/-/trycatch-1.5.11.tgz",
+          "integrity": "sha1-unfr8Y8QyrQ5bAzsUkvfa5Mq5Z0=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "1.1.0",
+            "hookit": "0.1.3"
+          },
+          "dependencies": {
+            "hookit": {
+              "version": "0.1.3",
+              "resolved": "https://unpm.uberinternal.com/hookit/-/hookit-0.1.3.tgz",
+              "integrity": "sha1-pvsSHfXy6NbKMsYm7bk7rzGEVD8=",
+              "dev": true
+            }
+          }
         }
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://unpm.uberinternal.com/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
-    "functional-red-black-tree": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://unpm.uberinternal.com/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0"
-      }
-    },
-    "glob": {
-      "version": "7.1.2",
-      "resolved": "https://unpm.uberinternal.com/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
-    },
-    "globals": {
-      "version": "11.5.0",
-      "resolved": "https://unpm.uberinternal.com/globals/-/globals-11.5.0.tgz",
-      "integrity": "sha512-hYyf+kI8dm3nORsiiXUQigOU62hDLfJ9G01uyGMxhc6BKsircrUhC4uJPQPUSuq2GrTmiiEt7ewxlMdBewfmKQ==",
-      "dev": true
-    },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://unpm.uberinternal.com/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
-    },
-    "got": {
-      "version": "5.7.1",
-      "resolved": "https://unpm.uberinternal.com/got/-/got-5.7.1.tgz",
-      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
-      "dev": true,
-      "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer2": "0.1.4",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.1",
-        "node-status-codes": "1.0.0",
-        "object-assign": "4.1.1",
-        "parse-json": "2.2.0",
-        "pinkie-promise": "2.0.1",
-        "read-all-stream": "3.1.0",
-        "readable-stream": "2.3.6",
-        "timed-out": "3.1.3",
-        "unzip-response": "1.0.2",
-        "url-parse-lax": "1.0.0"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://unpm.uberinternal.com/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
-    },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "dev": true
-    },
-    "har-validator": {
-      "version": "5.0.3",
-      "resolved": "https://unpm.uberinternal.com/har-validator/-/har-validator-5.0.3.tgz",
-      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-      "dev": true,
-      "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
-      }
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://unpm.uberinternal.com/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "1.1.1"
-      }
-    },
-    "has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://unpm.uberinternal.com/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "hookit": {
-      "version": "0.1.3",
-      "resolved": "https://unpm.uberinternal.com/hookit/-/hookit-0.1.3.tgz",
-      "integrity": "sha1-pvsSHfXy6NbKMsYm7bk7rzGEVD8=",
-      "dev": true
-    },
-    "http-errors": {
-      "version": "1.6.3",
-      "resolved": "https://unpm.uberinternal.com/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-      "requires": {
-        "depd": "1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://unpm.uberinternal.com/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.2"
-      }
-    },
-    "iconv-lite": {
-      "version": "0.4.23",
-      "resolved": "https://unpm.uberinternal.com/iconv-lite/-/iconv-lite-0.4.23.tgz",
-      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-      "requires": {
-        "safer-buffer": "2.1.2"
-      }
-    },
-    "ignore": {
-      "version": "3.3.8",
-      "resolved": "https://unpm.uberinternal.com/ignore/-/ignore-3.3.8.tgz",
-      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
-      "dev": true
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://unpm.uberinternal.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "individual": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/individual/-/individual-2.0.0.tgz",
-      "integrity": "sha1-gzsJfa0jKU52EXqY+zjg2a1hu5c="
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://unpm.uberinternal.com/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://unpm.uberinternal.com/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-    },
-    "ini": {
-      "version": "1.3.5",
-      "resolved": "https://unpm.uberinternal.com/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-    },
-    "inquirer": {
-      "version": "3.3.0",
-      "resolved": "https://unpm.uberinternal.com/inquirer/-/inquirer-3.3.0.tgz",
-      "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "3.1.0",
-        "chalk": "2.4.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.2.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.10",
-        "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
-      }
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://unpm.uberinternal.com/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://unpm.uberinternal.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://unpm.uberinternal.com/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://unpm.uberinternal.com/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
-    },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
-    },
-    "is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-      "dev": true
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
-    },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.1"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
-    },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://unpm.uberinternal.com/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
-    },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://unpm.uberinternal.com/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.3"
-      }
-    },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true
-    },
-    "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-      "dev": true
-    },
-    "is-stream": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
-    },
-    "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
-    },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
-    "is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
-      "dev": true
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://unpm.uberinternal.com/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
-    "istanbul-lib-coverage": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz",
-      "integrity": "sha512-yMSw5xLIbdaxiVXHk3amfNM2WeBxLrwH/BCyZ9HvA/fylwziAIJOG2rKqWyLqEJqwKT725vxxqidv+SyynnGAA==",
-      "dev": true
-    },
-    "istanbul-lib-instrument": {
-      "version": "2.2.0",
-      "resolved": "https://unpm.uberinternal.com/istanbul-lib-instrument/-/istanbul-lib-instrument-2.2.0.tgz",
-      "integrity": "sha512-ozQGtlIw+/a/F3n6QwWiuuyRAPp64+g2GVsKYsIez0sgIEzkU5ZpL2uZ5pmAzbEJ82anlRaPlOQZzkRXspgJyg==",
-      "dev": true,
-      "requires": {
-        "@babel/generator": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
-        "istanbul-lib-coverage": "2.0.0",
-        "semver": "5.5.0"
       }
     },
     "itape": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/itape/-/itape-1.9.1.tgz",
+      "resolved": "https://unpm.uberinternal.com/itape/-/itape-1.9.1.tgz",
       "integrity": "sha1-zfshrAp3o62CGbiR1+3SW0g2tJk=",
       "dev": true,
       "requires": {
@@ -1532,32 +2517,1497 @@
         "parents": "1.0.1",
         "process": "0.10.1",
         "readable-stream": "1.1.14",
-        "resolve": "1.3.2",
+        "resolve": "1.8.1",
         "tap-out": "git://github.com/Raynos/tap-out.git#ba074212dd3da3319e07b4a32807bdd720308a4b",
         "xtend": "4.0.1"
       },
       "dependencies": {
         "home-path": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/home-path/-/home-path-0.1.2.tgz",
+          "resolved": "https://unpm.uberinternal.com/home-path/-/home-path-0.1.2.tgz",
           "integrity": "sha1-PbJsojrcFE/uqPHi18j2yJDL/io=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://unpm.uberinternal.com/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": "https://unpm.uberinternal.com/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+              "dev": true
+            }
+          }
+        },
+        "parents": {
+          "version": "1.0.1",
+          "resolved": "https://unpm.uberinternal.com/parents/-/parents-1.0.1.tgz",
+          "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+          "dev": true,
+          "requires": {
+            "path-platform": "0.11.15"
+          },
+          "dependencies": {
+            "path-platform": {
+              "version": "0.11.15",
+              "resolved": "https://unpm.uberinternal.com/path-platform/-/path-platform-0.11.15.tgz",
+              "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+              "dev": true
+            }
+          }
+        },
+        "process": {
+          "version": "0.10.1",
+          "resolved": "https://unpm.uberinternal.com/process/-/process-0.10.1.tgz",
+          "integrity": "sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://unpm.uberinternal.com/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          },
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.2",
+              "resolved": "https://unpm.uberinternal.com/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+              "dev": true
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "resolved": "https://unpm.uberinternal.com/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+              "dev": true
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "resolved": "https://unpm.uberinternal.com/isarray/-/isarray-0.0.1.tgz",
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+              "dev": true
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "resolved": "https://unpm.uberinternal.com/string_decoder/-/string_decoder-0.10.31.tgz",
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+              "dev": true
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.8.1",
+          "resolved": "https://unpm.uberinternal.com/resolve/-/resolve-1.8.1.tgz",
+          "integrity": "sha1-gvHsGaQjrB+9CAsLqwa6NuhKeiY=",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          },
+          "dependencies": {
+            "path-parse": {
+              "version": "1.0.5",
+              "resolved": "https://unpm.uberinternal.com/path-parse/-/path-parse-1.0.5.tgz",
+              "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+              "dev": true
+            }
+          }
+        },
+        "tap-out": {
+          "version": "git://github.com/Raynos/tap-out.git#ba074212dd3da3319e07b4a32807bdd720308a4b",
+          "dev": true,
+          "requires": {
+            "re-emitter": "1.1.3",
+            "split": "0.3.3",
+            "through2": "0.6.5",
+            "trim": "0.0.1"
+          },
+          "dependencies": {
+            "re-emitter": {
+              "version": "1.1.3",
+              "resolved": "https://unpm.uberinternal.com/re-emitter/-/re-emitter-1.1.3.tgz",
+              "integrity": "sha1-+p4xn/3u6zWycpbvDz03TawvUqc=",
+              "dev": true
+            },
+            "split": {
+              "version": "0.3.3",
+              "resolved": "https://unpm.uberinternal.com/split/-/split-0.3.3.tgz",
+              "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+              "dev": true,
+              "requires": {
+                "through": "2.3.8"
+              },
+              "dependencies": {
+                "through": {
+                  "version": "2.3.8",
+                  "resolved": "https://unpm.uberinternal.com/through/-/through-2.3.8.tgz",
+                  "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+                  "dev": true
+                }
+              }
+            },
+            "through2": {
+              "version": "0.6.5",
+              "resolved": "https://unpm.uberinternal.com/through2/-/through2-0.6.5.tgz",
+              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+              "dev": true,
+              "requires": {
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.34",
+                  "resolved": "https://unpm.uberinternal.com/readable-stream/-/readable-stream-1.0.34.tgz",
+                  "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                  "dev": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "0.0.1",
+                    "string_decoder": "0.10.31"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "resolved": "https://unpm.uberinternal.com/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                      "dev": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "resolved": "https://unpm.uberinternal.com/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                      "dev": true
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "resolved": "https://unpm.uberinternal.com/isarray/-/isarray-0.0.1.tgz",
+                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+                      "dev": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "resolved": "https://unpm.uberinternal.com/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "trim": {
+              "version": "0.0.1",
+              "resolved": "https://unpm.uberinternal.com/trim/-/trim-0.0.1.tgz",
+              "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
+    "marked-man": {
+      "version": "0.2.1",
+      "resolved": "https://unpm.uberinternal.com/marked-man/-/marked-man-0.2.1.tgz",
+      "integrity": "sha1-8lknFIHeO1ByY0ifUiG3xaz9I4M=",
+      "dev": true,
+      "requires": {
+        "marked": "0.3.19"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "0.3.19",
+          "resolved": "https://unpm.uberinternal.com/marked/-/marked-0.3.19.tgz",
+          "integrity": "sha1-XUf3CcTJ/Dwha21GEnKA9As515A=",
+          "dev": true
+        }
+      }
+    },
+    "my-local-ip": {
+      "version": "1.0.0",
+      "resolved": "https://unpm.uberinternal.com/my-local-ip/-/my-local-ip-1.0.0.tgz",
+      "integrity": "sha1-N1hVVaT/GYUwntrHwqBFpGa+bDI="
+    },
+    "nyc": {
+      "version": "6.4.4",
+      "resolved": "https://unpm.uberinternal.com/nyc/-/nyc-6.4.4.tgz",
+      "integrity": "sha1-Q9fb+rg+EWq38p0STq7JuH+5/pM=",
+      "dev": true,
+      "requires": {
+        "append-transform": "0.4.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.2.0",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "1.1.2",
+        "foreground-child": "1.4.0",
+        "glob": "7.0.3",
+        "istanbul": "0.4.3",
+        "lodash": "4.11.2",
+        "md5-hex": "1.3.0",
+        "micromatch": "2.3.8",
+        "mkdirp": "0.5.1",
+        "pkg-up": "1.0.0",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.5.2",
+        "signal-exit": "2.1.2",
+        "source-map": "0.5.6",
+        "spawn-wrap": "1.2.2",
+        "strip-bom": "3.0.0",
+        "yargs": "4.7.0"
+      },
+      "dependencies": {
+        "append-transform": {
+          "version": "0.4.0",
+          "resolved": "http://52.202.166.115/a/append-transform/_attachments/append-transform-0.4.0.tgz",
+          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "dev": true,
+          "requires": {
+            "default-require-extensions": "1.0.0"
+          }
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "resolved": "http://52.202.166.115/a/arrify/_attachments/arrify-1.0.1.tgz",
+          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+          "dev": true
+        },
+        "caching-transform": {
+          "version": "1.0.1",
+          "resolved": "http://52.202.166.115/c/caching-transform/_attachments/caching-transform-1.0.1.tgz",
+          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "dev": true,
+          "requires": {
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.1.4"
+          },
+          "dependencies": {
+            "write-file-atomic": {
+              "version": "1.1.4",
+              "resolved": "http://52.202.166.115/w/write-file-atomic/_attachments/write-file-atomic-1.1.4.tgz",
+              "integrity": "sha1-sfUtwujcDjywTRh6JfdYo4qQyjs=",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "4.1.4",
+                "imurmurhash": "0.1.4",
+                "slide": "1.1.6"
+              },
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "4.1.4",
+                  "resolved": "http://52.202.166.115/g/graceful-fs/_attachments/graceful-fs-4.1.4.tgz",
+                  "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                  "dev": true
+                },
+                "imurmurhash": {
+                  "version": "0.1.4",
+                  "resolved": "http://52.202.166.115/i/imurmurhash/_attachments/imurmurhash-0.1.4.tgz",
+                  "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+                  "dev": true
+                },
+                "slide": {
+                  "version": "1.1.6",
+                  "resolved": "http://52.202.166.115/s/slide/_attachments/slide-1.1.6.tgz",
+                  "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "convert-source-map": {
+          "version": "1.2.0",
+          "resolved": "http://52.202.166.115/c/convert-source-map/_attachments/convert-source-map-1.2.0.tgz",
+          "integrity": "sha1-RMCMJQbxD7PKb9iI1aNETPjWpmk=",
+          "dev": true
+        },
+        "default-require-extensions": {
+          "version": "1.0.0",
+          "resolved": "http://52.202.166.115/d/default-require-extensions/_attachments/default-require-extensions-1.0.0.tgz",
+          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "dev": true,
+          "requires": {
+            "strip-bom": "2.0.0"
+          },
+          "dependencies": {
+            "strip-bom": {
+              "version": "2.0.0",
+              "resolved": "http://52.202.166.115/s/strip-bom/_attachments/strip-bom-2.0.0.tgz",
+              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+              "dev": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              },
+              "dependencies": {
+                "is-utf8": {
+                  "version": "0.2.1",
+                  "resolved": "http://52.202.166.115/i/is-utf8/_attachments/is-utf8-0.2.1.tgz",
+                  "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "resolved": "http://52.202.166.115/f/find-cache-dir/_attachments/find-cache-dir-0.1.1.tgz",
+          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "dev": true,
+          "requires": {
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
+          },
+          "dependencies": {
+            "commondir": {
+              "version": "1.0.1",
+              "resolved": "http://52.202.166.115/c/commondir/_attachments/commondir-1.0.1.tgz",
+              "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+              "dev": true
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "resolved": "http://52.202.166.115/p/pkg-dir/_attachments/pkg-dir-1.0.0.tgz",
+              "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+              "dev": true,
+              "requires": {
+                "find-up": "1.1.2"
+              }
+            }
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "http://52.202.166.115/f/find-up/_attachments/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "2.1.0",
+              "resolved": "http://52.202.166.115/p/path-exists/_attachments/path-exists-2.1.0.tgz",
+              "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+              "dev": true,
+              "requires": {
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "resolved": "http://52.202.166.115/p/pinkie-promise/_attachments/pinkie-promise-2.0.1.tgz",
+              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+              "dev": true,
+              "requires": {
+                "pinkie": "2.0.4"
+              },
+              "dependencies": {
+                "pinkie": {
+                  "version": "2.0.4",
+                  "resolved": "http://52.202.166.115/p/pinkie/_attachments/pinkie-2.0.4.tgz",
+                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "foreground-child": {
+          "version": "1.4.0",
+          "resolved": "http://52.202.166.115/f/foreground-child/_attachments/foreground-child-1.4.0.tgz",
+          "integrity": "sha1-UR/iPjyPgOLSiAeQiphJKXLqyn4=",
+          "dev": true,
+          "requires": {
+            "cross-spawn-async": "2.2.2",
+            "signal-exit": "2.1.2",
+            "which": "1.2.8"
+          },
+          "dependencies": {
+            "cross-spawn-async": {
+              "version": "2.2.2",
+              "resolved": "http://52.202.166.115/c/cross-spawn-async/_attachments/cross-spawn-async-2.2.2.tgz",
+              "integrity": "sha1-kN6ptpIPA7L3vHSZYVABrubyMX4=",
+              "dev": true,
+              "requires": {
+                "lru-cache": "4.0.1",
+                "which": "1.2.8"
+              },
+              "dependencies": {
+                "lru-cache": {
+                  "version": "4.0.1",
+                  "resolved": "http://52.202.166.115/l/lru-cache/_attachments/lru-cache-4.0.1.tgz",
+                  "integrity": "sha1-E0OVXtry432bnn7nJB4nxLn7cr4=",
+                  "dev": true,
+                  "requires": {
+                    "pseudomap": "1.0.2",
+                    "yallist": "2.0.0"
+                  },
+                  "dependencies": {
+                    "pseudomap": {
+                      "version": "1.0.2",
+                      "resolved": "http://52.202.166.115/p/pseudomap/_attachments/pseudomap-1.0.2.tgz",
+                      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+                      "dev": true
+                    },
+                    "yallist": {
+                      "version": "2.0.0",
+                      "resolved": "http://52.202.166.115/y/yallist/_attachments/yallist-2.0.0.tgz",
+                      "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "7.0.3",
+          "resolved": "http://52.202.166.115/g/glob/_attachments/glob-7.0.3.tgz",
+          "integrity": "sha1-CqI1kxpKlqwT1g/6wvuHe9btT1g=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.4",
+            "inherits": "2.0.1",
+            "minimatch": "3.0.0",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.0"
+          },
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "resolved": "http://52.202.166.115/i/inflight/_attachments/inflight-1.0.4.tgz",
+              "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+              "dev": true,
+              "requires": {
+                "once": "1.3.3",
+                "wrappy": "1.0.1"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "http://52.202.166.115/w/wrappy/_attachments/wrappy-1.0.1.tgz",
+                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+                  "dev": true
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "resolved": "http://52.202.166.115/i/inherits/_attachments/inherits-2.0.1.tgz",
+              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "3.0.0",
+              "resolved": "http://52.202.166.115/m/minimatch/_attachments/minimatch-3.0.0.tgz",
+              "integrity": "sha1-UjYVelHk8ATBd/s8Un/33Xjw74M=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.4"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.4",
+                  "resolved": "http://52.202.166.115/b/brace-expansion/_attachments/brace-expansion-1.1.4.tgz",
+                  "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "0.4.1",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.1",
+                      "resolved": "http://52.202.166.115/b/balanced-match/_attachments/balanced-match-0.4.1.tgz",
+                      "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "http://52.202.166.115/c/concat-map/_attachments/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.3",
+              "resolved": "http://52.202.166.115/o/once/_attachments/once-1.3.3.tgz",
+              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.1"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "http://52.202.166.115/w/wrappy/_attachments/wrappy-1.0.1.tgz",
+                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+                  "dev": true
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "resolved": "http://52.202.166.115/p/path-is-absolute/_attachments/path-is-absolute-1.0.0.tgz",
+              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+              "dev": true
+            }
+          }
+        },
+        "istanbul": {
+          "version": "0.4.3",
+          "resolved": "http://52.202.166.115/i/istanbul/_attachments/istanbul-0.4.3.tgz",
+          "integrity": "sha1-W3FO4K5JOsXvIEuZ84crzu9z1To=",
+          "dev": true,
+          "requires": {
+            "abbrev": "1.0.7",
+            "async": "1.5.2",
+            "escodegen": "1.8.0",
+            "esprima": "2.7.2",
+            "fileset": "0.2.1",
+            "handlebars": "4.0.5",
+            "js-yaml": "3.6.0",
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "once": "1.3.3",
+            "resolve": "1.1.7",
+            "supports-color": "3.1.2",
+            "which": "1.2.8",
+            "wordwrap": "1.0.0"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "resolved": "http://52.202.166.115/a/abbrev/_attachments/abbrev-1.0.7.tgz",
+              "integrity": "sha1-W2A1su6dT7XPhZ8Iqb6BsghJGEM=",
+              "dev": true
+            },
+            "async": {
+              "version": "1.5.2",
+              "resolved": "http://52.202.166.115/a/async/_attachments/async-1.5.2.tgz",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+              "dev": true
+            },
+            "escodegen": {
+              "version": "1.8.0",
+              "resolved": "http://52.202.166.115/e/escodegen/_attachments/escodegen-1.8.0.tgz",
+              "integrity": "sha1-skaq6CnOc9WeLFVyc1nt0cEwqBs=",
+              "dev": true,
+              "requires": {
+                "esprima": "2.7.2",
+                "estraverse": "1.9.3",
+                "esutils": "2.0.2",
+                "optionator": "0.8.1",
+                "source-map": "0.2.0"
+              },
+              "dependencies": {
+                "estraverse": {
+                  "version": "1.9.3",
+                  "resolved": "http://52.202.166.115/e/estraverse/_attachments/estraverse-1.9.3.tgz",
+                  "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+                  "dev": true
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "resolved": "http://52.202.166.115/e/esutils/_attachments/esutils-2.0.2.tgz",
+                  "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+                  "dev": true
+                },
+                "optionator": {
+                  "version": "0.8.1",
+                  "resolved": "http://52.202.166.115/o/optionator/_attachments/optionator-0.8.1.tgz",
+                  "integrity": "sha1-4xtJMs3V+4Yqiw0QvGPT7h7H14s=",
+                  "dev": true,
+                  "requires": {
+                    "deep-is": "0.1.3",
+                    "fast-levenshtein": "1.1.3",
+                    "levn": "0.3.0",
+                    "prelude-ls": "1.1.2",
+                    "type-check": "0.3.2",
+                    "wordwrap": "1.0.0"
+                  },
+                  "dependencies": {
+                    "deep-is": {
+                      "version": "0.1.3",
+                      "resolved": "http://52.202.166.115/d/deep-is/_attachments/deep-is-0.1.3.tgz",
+                      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+                      "dev": true
+                    },
+                    "fast-levenshtein": {
+                      "version": "1.1.3",
+                      "resolved": "http://52.202.166.115/f/fast-levenshtein/_attachments/fast-levenshtein-1.1.3.tgz",
+                      "integrity": "sha1-KuezKrweYS2kik4ThJuIii9h5+k=",
+                      "dev": true
+                    },
+                    "levn": {
+                      "version": "0.3.0",
+                      "resolved": "http://52.202.166.115/l/levn/_attachments/levn-0.3.0.tgz",
+                      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+                      "dev": true,
+                      "requires": {
+                        "prelude-ls": "1.1.2",
+                        "type-check": "0.3.2"
+                      }
+                    },
+                    "prelude-ls": {
+                      "version": "1.1.2",
+                      "resolved": "http://52.202.166.115/p/prelude-ls/_attachments/prelude-ls-1.1.2.tgz",
+                      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+                      "dev": true
+                    },
+                    "type-check": {
+                      "version": "0.3.2",
+                      "resolved": "http://52.202.166.115/t/type-check/_attachments/type-check-0.3.2.tgz",
+                      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+                      "dev": true,
+                      "requires": {
+                        "prelude-ls": "1.1.2"
+                      }
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.2.0",
+                  "resolved": "http://52.202.166.115/s/source-map/_attachments/source-map-0.2.0.tgz",
+                  "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "amdefine": "1.0.0"
+                  },
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "http://52.202.166.115/a/amdefine/_attachments/amdefine-1.0.0.tgz",
+                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                      "dev": true,
+                      "optional": true
+                    }
+                  }
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.7.2",
+              "resolved": "http://52.202.166.115/e/esprima/_attachments/esprima-2.7.2.tgz",
+              "integrity": "sha1-9DvlQ2CZhOrkTJM6xjNSpq818zk=",
+              "dev": true
+            },
+            "fileset": {
+              "version": "0.2.1",
+              "resolved": "http://52.202.166.115/f/fileset/_attachments/fileset-0.2.1.tgz",
+              "integrity": "sha1-WI74lzxmI7KnbfRlEFaWuWqsgGc=",
+              "dev": true,
+              "requires": {
+                "glob": "5.0.15",
+                "minimatch": "2.0.10"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "5.0.15",
+                  "resolved": "http://52.202.166.115/g/glob/_attachments/glob-5.0.15.tgz",
+                  "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                  "dev": true,
+                  "requires": {
+                    "inflight": "1.0.4",
+                    "inherits": "2.0.1",
+                    "minimatch": "2.0.10",
+                    "once": "1.3.3",
+                    "path-is-absolute": "1.0.0"
+                  },
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "resolved": "http://52.202.166.115/i/inflight/_attachments/inflight-1.0.4.tgz",
+                      "integrity": "sha1-bLtFIevVHODsCpNr/XZX736bFyo=",
+                      "dev": true,
+                      "requires": {
+                        "once": "1.3.3",
+                        "wrappy": "1.0.1"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "resolved": "http://52.202.166.115/w/wrappy/_attachments/wrappy-1.0.1.tgz",
+                          "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "resolved": "http://52.202.166.115/i/inherits/_attachments/inherits-2.0.1.tgz",
+                      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                      "dev": true
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "resolved": "http://52.202.166.115/p/path-is-absolute/_attachments/path-is-absolute-1.0.0.tgz",
+                      "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
+                      "dev": true
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "resolved": "http://52.202.166.115/m/minimatch/_attachments/minimatch-2.0.10.tgz",
+                  "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.4"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.4",
+                      "resolved": "http://52.202.166.115/b/brace-expansion/_attachments/brace-expansion-1.1.4.tgz",
+                      "integrity": "sha1-RkogTHf0gsCFwqNsRWu/uvtnoSc=",
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.4.1",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.1",
+                          "resolved": "http://52.202.166.115/b/balanced-match/_attachments/balanced-match-0.4.1.tgz",
+                          "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "resolved": "http://52.202.166.115/c/concat-map/_attachments/concat-map-0.0.1.tgz",
+                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "handlebars": {
+              "version": "4.0.5",
+              "resolved": "http://52.202.166.115/h/handlebars/_attachments/handlebars-4.0.5.tgz",
+              "integrity": "sha1-ksbta7FkEQxQ1NjQ+93HCAbG+Oc=",
+              "dev": true,
+              "requires": {
+                "async": "1.5.2",
+                "optimist": "0.6.1",
+                "source-map": "0.4.4",
+                "uglify-js": "2.6.2"
+              },
+              "dependencies": {
+                "optimist": {
+                  "version": "0.6.1",
+                  "resolved": "http://52.202.166.115/o/optimist/_attachments/optimist-0.6.1.tgz",
+                  "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.10",
+                    "wordwrap": "0.0.3"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "resolved": "http://52.202.166.115/m/minimist/_attachments/minimist-0.0.10.tgz",
+                      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                      "dev": true
+                    },
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "resolved": "http://52.202.166.115/w/wordwrap/_attachments/wordwrap-0.0.3.tgz",
+                      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                      "dev": true
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "resolved": "http://52.202.166.115/s/source-map/_attachments/source-map-0.4.4.tgz",
+                  "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                  "dev": true,
+                  "requires": {
+                    "amdefine": "1.0.0"
+                  },
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "resolved": "http://52.202.166.115/a/amdefine/_attachments/amdefine-1.0.0.tgz",
+                      "integrity": "sha1-/RdHRwDLXMnCtwnwvp0jzjwZjDM=",
+                      "dev": true
+                    }
+                  }
+                },
+                "uglify-js": {
+                  "version": "2.6.2",
+                  "resolved": "http://52.202.166.115/u/uglify-js/_attachments/uglify-js-2.6.2.tgz",
+                  "integrity": "sha1-9QvoikLNOWpiUdxSqzcvccwS/vA=",
+                  "dev": true,
+                  "optional": true,
+                  "requires": {
+                    "async": "0.2.10",
+                    "source-map": "0.5.6",
+                    "uglify-to-browserify": "1.0.2",
+                    "yargs": "3.10.0"
+                  },
+                  "dependencies": {
+                    "async": {
+                      "version": "0.2.10",
+                      "resolved": "http://52.202.166.115/a/async/_attachments/async-0.2.10.tgz",
+                      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "source-map": {
+                      "version": "0.5.6",
+                      "resolved": "http://52.202.166.115/s/source-map/_attachments/source-map-0.5.6.tgz",
+                      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "uglify-to-browserify": {
+                      "version": "1.0.2",
+                      "resolved": "http://52.202.166.115/u/uglify-to-browserify/_attachments/uglify-to-browserify-1.0.2.tgz",
+                      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+                      "dev": true,
+                      "optional": true
+                    },
+                    "yargs": {
+                      "version": "3.10.0",
+                      "resolved": "http://52.202.166.115/y/yargs/_attachments/yargs-3.10.0.tgz",
+                      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "camelcase": "1.2.1",
+                        "cliui": "2.1.0",
+                        "decamelize": "1.2.0",
+                        "window-size": "0.1.0"
+                      },
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "resolved": "http://52.202.166.115/c/camelcase/_attachments/camelcase-1.2.1.tgz",
+                          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "cliui": {
+                          "version": "2.1.0",
+                          "resolved": "http://52.202.166.115/c/cliui/_attachments/cliui-2.1.0.tgz",
+                          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+                          "dev": true,
+                          "optional": true,
+                          "requires": {
+                            "center-align": "0.1.3",
+                            "right-align": "0.1.3",
+                            "wordwrap": "0.0.2"
+                          },
+                          "dependencies": {
+                            "center-align": {
+                              "version": "0.1.3",
+                              "resolved": "http://52.202.166.115/c/center-align/_attachments/center-align-0.1.3.tgz",
+                              "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "align-text": "0.1.4",
+                                "lazy-cache": "1.0.4"
+                              },
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.4",
+                                  "resolved": "http://52.202.166.115/a/align-text/_attachments/align-text-0.1.4.tgz",
+                                  "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "kind-of": "3.0.3",
+                                    "longest": "1.0.1",
+                                    "repeat-string": "1.5.4"
+                                  },
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.0.3",
+                                      "resolved": "http://52.202.166.115/k/kind-of/_attachments/kind-of-3.0.3.tgz",
+                                      "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
+                                      "dev": true,
+                                      "optional": true,
+                                      "requires": {
+                                        "is-buffer": "1.1.3"
+                                      },
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.3",
+                                          "resolved": "http://52.202.166.115/i/is-buffer/_attachments/is-buffer-1.1.3.tgz",
+                                          "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
+                                          "dev": true,
+                                          "optional": true
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "resolved": "http://52.202.166.115/l/longest/_attachments/longest-1.0.1.tgz",
+                                      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                      "dev": true,
+                                      "optional": true
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.4",
+                                      "resolved": "http://52.202.166.115/r/repeat-string/_attachments/repeat-string-1.5.4.tgz",
+                                      "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                },
+                                "lazy-cache": {
+                                  "version": "1.0.4",
+                                  "resolved": "http://52.202.166.115/l/lazy-cache/_attachments/lazy-cache-1.0.4.tgz",
+                                  "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+                                  "dev": true,
+                                  "optional": true
+                                }
+                              }
+                            },
+                            "right-align": {
+                              "version": "0.1.3",
+                              "resolved": "http://52.202.166.115/r/right-align/_attachments/right-align-0.1.3.tgz",
+                              "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+                              "dev": true,
+                              "optional": true,
+                              "requires": {
+                                "align-text": "0.1.4"
+                              },
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.4",
+                                  "resolved": "http://52.202.166.115/a/align-text/_attachments/align-text-0.1.4.tgz",
+                                  "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+                                  "dev": true,
+                                  "optional": true,
+                                  "requires": {
+                                    "kind-of": "3.0.3",
+                                    "longest": "1.0.1",
+                                    "repeat-string": "1.5.4"
+                                  },
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.0.3",
+                                      "resolved": "http://52.202.166.115/k/kind-of/_attachments/kind-of-3.0.3.tgz",
+                                      "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
+                                      "dev": true,
+                                      "optional": true,
+                                      "requires": {
+                                        "is-buffer": "1.1.3"
+                                      },
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.3",
+                                          "resolved": "http://52.202.166.115/i/is-buffer/_attachments/is-buffer-1.1.3.tgz",
+                                          "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
+                                          "dev": true,
+                                          "optional": true
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "resolved": "http://52.202.166.115/l/longest/_attachments/longest-1.0.1.tgz",
+                                      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+                                      "dev": true,
+                                      "optional": true
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.4",
+                                      "resolved": "http://52.202.166.115/r/repeat-string/_attachments/repeat-string-1.5.4.tgz",
+                                      "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                                      "dev": true,
+                                      "optional": true
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "wordwrap": {
+                              "version": "0.0.2",
+                              "resolved": "http://52.202.166.115/w/wordwrap/_attachments/wordwrap-0.0.2.tgz",
+                              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                              "dev": true,
+                              "optional": true
+                            }
+                          }
+                        },
+                        "decamelize": {
+                          "version": "1.2.0",
+                          "resolved": "http://52.202.166.115/d/decamelize/_attachments/decamelize-1.2.0.tgz",
+                          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+                          "dev": true,
+                          "optional": true
+                        },
+                        "window-size": {
+                          "version": "0.1.0",
+                          "resolved": "http://52.202.166.115/w/window-size/_attachments/window-size-0.1.0.tgz",
+                          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+                          "dev": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "js-yaml": {
+              "version": "3.6.0",
+              "resolved": "http://52.202.166.115/j/js-yaml/_attachments/js-yaml-3.6.0.tgz",
+              "integrity": "sha1-O3vzJW3VmPYPi2+Op1UUpYWiTcY=",
+              "dev": true,
+              "requires": {
+                "argparse": "1.0.7",
+                "esprima": "2.7.2"
+              },
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.7",
+                  "resolved": "http://52.202.166.115/a/argparse/_attachments/argparse-1.0.7.tgz",
+                  "integrity": "sha1-wolQZIBVeBDxSovGLXoG9j7X+VE=",
+                  "dev": true,
+                  "requires": {
+                    "sprintf-js": "1.0.3"
+                  },
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.3",
+                      "resolved": "http://52.202.166.115/s/sprintf-js/_attachments/sprintf-js-1.0.3.tgz",
+                      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "resolved": "http://52.202.166.115/n/nopt/_attachments/nopt-3.0.6.tgz",
+              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+              "dev": true,
+              "requires": {
+                "abbrev": "1.0.7"
+              }
+            },
+            "once": {
+              "version": "1.3.3",
+              "resolved": "http://52.202.166.115/o/once/_attachments/once-1.3.3.tgz",
+              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.1"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "resolved": "http://52.202.166.115/w/wrappy/_attachments/wrappy-1.0.1.tgz",
+                  "integrity": "sha1-HmWWmWXMvC20VIxrhKbyxa7dRzk=",
+                  "dev": true
+                }
+              }
+            },
+            "resolve": {
+              "version": "1.1.7",
+              "resolved": "http://52.202.166.115/r/resolve/_attachments/resolve-1.1.7.tgz",
+              "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "3.1.2",
+              "resolved": "http://52.202.166.115/s/supports-color/_attachments/supports-color-3.1.2.tgz",
+              "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+              "dev": true,
+              "requires": {
+                "has-flag": "1.0.0"
+              },
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "resolved": "http://52.202.166.115/h/has-flag/_attachments/has-flag-1.0.0.tgz",
+                  "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+                  "dev": true
+                }
+              }
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "resolved": "http://52.202.166.115/w/wordwrap/_attachments/wordwrap-1.0.0.tgz",
+              "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+              "dev": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.11.2",
+          "resolved": "http://52.202.166.115/l/lodash/_attachments/lodash-4.11.2.tgz",
+          "integrity": "sha1-1rQzixEKWOIdrlzrz9u/0rxM2zs=",
+          "dev": true
+        },
+        "md5-hex": {
+          "version": "1.3.0",
+          "resolved": "http://52.202.166.115/m/md5-hex/_attachments/md5-hex-1.3.0.tgz",
+          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "dev": true,
+          "requires": {
+            "md5-o-matic": "0.1.1"
+          },
+          "dependencies": {
+            "md5-o-matic": {
+              "version": "0.1.1",
+              "resolved": "http://52.202.166.115/m/md5-o-matic/_attachments/md5-o-matic-0.1.1.tgz",
+              "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+              "dev": true
+            }
+          }
+        },
+        "micromatch": {
+          "version": "2.3.8",
+          "resolved": "http://52.202.166.115/m/micromatch/_attachments/micromatch-2.3.8.tgz",
+          "integrity": "sha1-lPv4837Z7eyga/HI97dD+19vWFQ=",
+          "dev": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.4",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.0",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.0.3",
+            "normalize-path": "2.0.1",
+            "object.omit": "2.0.0",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
+          },
+          "dependencies": {
+            "arr-diff": {
+              "version": "2.0.0",
+              "resolved": "http://52.202.166.115/a/arr-diff/_attachments/arr-diff-2.0.0.tgz",
+              "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+              "dev": true,
+              "requires": {
+                "arr-flatten": "1.0.1"
+              },
+              "dependencies": {
+                "arr-flatten": {
+                  "version": "1.0.1",
+                  "resolved": "http://52.202.166.115/a/arr-flatten/_attachments/arr-flatten-1.0.1.tgz",
+                  "integrity": "sha1-5f/lTUXhnzLyFukeuZyM6JK7YEs=",
+                  "dev": true
+                }
+              }
+            },
+            "array-unique": {
+              "version": "0.2.1",
+              "resolved": "http://52.202.166.115/a/array-unique/_attachments/array-unique-0.2.1.tgz",
+              "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+              "dev": true
+            },
+            "braces": {
+              "version": "1.8.4",
+              "resolved": "http://52.202.166.115/b/braces/_attachments/braces-1.8.4.tgz",
+              "integrity": "sha1-deLWRW1IsG27UgXtY0QqO/xe784=",
+              "dev": true,
+              "requires": {
+                "expand-range": "1.8.2",
+                "preserve": "0.2.0",
+                "repeat-element": "1.1.2"
+              },
+              "dependencies": {
+                "expand-range": {
+                  "version": "1.8.2",
+                  "resolved": "http://52.202.166.115/e/expand-range/_attachments/expand-range-1.8.2.tgz",
+                  "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+                  "dev": true,
+                  "requires": {
+                    "fill-range": "2.2.3"
+                  },
+                  "dependencies": {
+                    "fill-range": {
+                      "version": "2.2.3",
+                      "resolved": "http://52.202.166.115/f/fill-range/_attachments/fill-range-2.2.3.tgz",
+                      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+                      "dev": true,
+                      "requires": {
+                        "is-number": "2.1.0",
+                        "isobject": "2.1.0",
+                        "randomatic": "1.1.5",
+                        "repeat-element": "1.1.2",
+                        "repeat-string": "1.5.4"
+                      },
+                      "dependencies": {
+                        "is-number": {
+                          "version": "2.1.0",
+                          "resolved": "http://52.202.166.115/i/is-number/_attachments/is-number-2.1.0.tgz",
+                          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                          "dev": true,
+                          "requires": {
+                            "kind-of": "3.0.3"
+                          }
+                        },
+                        "isobject": {
+                          "version": "2.1.0",
+                          "resolved": "http://52.202.166.115/i/isobject/_attachments/isobject-2.1.0.tgz",
+                          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                          "dev": true,
+                          "requires": {
+                            "isarray": "1.0.0"
+                          },
+                          "dependencies": {
+                            "isarray": {
+                              "version": "1.0.0",
+                              "resolved": "http://52.202.166.115/i/isarray/_attachments/isarray-1.0.0.tgz",
+                              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "randomatic": {
+                          "version": "1.1.5",
+                          "resolved": "http://52.202.166.115/r/randomatic/_attachments/randomatic-1.1.5.tgz",
+                          "integrity": "sha1-Xp718tVzxnvSuBJK6QtRVuRXhAs=",
+                          "dev": true,
+                          "requires": {
+                            "is-number": "2.1.0",
+                            "kind-of": "3.0.3"
+                          }
+                        },
+                        "repeat-string": {
+                          "version": "1.5.4",
+                          "resolved": "http://52.202.166.115/r/repeat-string/_attachments/repeat-string-1.5.4.tgz",
+                          "integrity": "sha1-ZOwMkeD0tHX5DVtkNlHj5uW2wtU=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "preserve": {
+                  "version": "0.2.0",
+                  "resolved": "http://52.202.166.115/p/preserve/_attachments/preserve-0.2.0.tgz",
+                  "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+                  "dev": true
+                },
+                "repeat-element": {
+                  "version": "1.1.2",
+                  "resolved": "http://52.202.166.115/r/repeat-element/_attachments/repeat-element-1.1.2.tgz",
+                  "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+                  "dev": true
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "0.1.5",
+              "resolved": "http://52.202.166.115/e/expand-brackets/_attachments/expand-brackets-0.1.5.tgz",
+              "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+              "dev": true,
+              "requires": {
+                "is-posix-bracket": "0.1.1"
+              },
+              "dependencies": {
+                "is-posix-bracket": {
+                  "version": "0.1.1",
+                  "resolved": "http://52.202.166.115/i/is-posix-bracket/_attachments/is-posix-bracket-0.1.1.tgz",
+                  "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+                  "dev": true
+                }
+              }
+            },
+            "extglob": {
+              "version": "0.3.2",
+              "resolved": "http://52.202.166.115/e/extglob/_attachments/extglob-0.3.2.tgz",
+              "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "filename-regex": {
+              "version": "2.0.0",
+              "resolved": "http://52.202.166.115/f/filename-regex/_attachments/filename-regex-2.0.0.tgz",
+              "integrity": "sha1-mW4+gEebmLmJfxWopYs9CE6SZ3U=",
+              "dev": true
+            },
+            "is-extglob": {
+              "version": "1.0.0",
+              "resolved": "http://52.202.166.115/i/is-extglob/_attachments/is-extglob-1.0.0.tgz",
+              "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+              "dev": true
+            },
+            "is-glob": {
+              "version": "2.0.1",
+              "resolved": "http://52.202.166.115/i/is-glob/_attachments/is-glob-2.0.1.tgz",
+              "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+              "dev": true,
+              "requires": {
+                "is-extglob": "1.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.0.3",
+              "resolved": "http://52.202.166.115/k/kind-of/_attachments/kind-of-3.0.3.tgz",
+              "integrity": "sha1-xhYIdH2BWwNiVW2zJ2Nip6OK3tM=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "1.1.3"
+              },
+              "dependencies": {
+                "is-buffer": {
+                  "version": "1.1.3",
+                  "resolved": "http://52.202.166.115/i/is-buffer/_attachments/is-buffer-1.1.3.tgz",
+                  "integrity": "sha1-24l/w/esotUN6UtsjCiWpHcWJ68=",
+                  "dev": true
+                }
+              }
+            },
+            "normalize-path": {
+              "version": "2.0.1",
+              "resolved": "http://52.202.166.115/n/normalize-path/_attachments/normalize-path-2.0.1.tgz",
+              "integrity": "sha1-R4hqwWYnYNQmG32XnSQXCdPOP3o=",
+              "dev": true
+            },
+            "object.omit": {
+              "version": "2.0.0",
+              "resolved": "http://52.202.166.115/o/object.omit/_attachments/object.omit-2.0.0.tgz",
+              "integrity": "sha1-hoWXMz1U5gZilAu0WGBd1q4S/pQ=",
+              "dev": true,
+              "requires": {
+                "for-own": "0.1.4",
+                "is-extendable": "0.1.1"
+              },
+              "dependencies": {
+                "for-own": {
+                  "version": "0.1.4",
+                  "resolved": "http://52.202.166.115/f/for-own/_attachments/for-own-0.1.4.tgz",
+                  "integrity": "sha1-AUm0GjkIjHUV9R6+HBOG1F+TUHI=",
+                  "dev": true,
+                  "requires": {
+                    "for-in": "0.1.5"
+                  },
+                  "dependencies": {
+                    "for-in": {
+                      "version": "0.1.5",
+                      "resolved": "http://52.202.166.115/f/for-in/_attachments/for-in-0.1.5.tgz",
+                      "integrity": "sha1-AHN04rbVxnQgoUeb23WgSHK3OMQ=",
+                      "dev": true
+                    }
+                  }
+                },
+                "is-extendable": {
+                  "version": "0.1.1",
+                  "resolved": "http://52.202.166.115/i/is-extendable/_attachments/is-extendable-0.1.1.tgz",
+                  "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+                  "dev": true
+                }
+              }
+            },
+            "parse-glob": {
+              "version": "3.0.4",
+              "resolved": "http://52.202.166.115/p/parse-glob/_attachments/parse-glob-3.0.4.tgz",
+              "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+              "dev": true,
+              "requires": {
+                "glob-base": "0.3.0",
+                "is-dotfile": "1.0.2",
+                "is-extglob": "1.0.0",
+                "is-glob": "2.0.1"
+              },
+              "dependencies": {
+                "glob-base": {
+                  "version": "0.3.0",
+                  "resolved": "http://52.202.166.115/g/glob-base/_attachments/glob-base-0.3.0.tgz",
+                  "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+                  "dev": true,
+                  "requires": {
+                    "glob-parent": "2.0.0",
+                    "is-glob": "2.0.1"
+                  },
+                  "dependencies": {
+                    "glob-parent": {
+                      "version": "2.0.0",
+                      "resolved": "http://52.202.166.115/g/glob-parent/_attachments/glob-parent-2.0.0.tgz",
+                      "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                      "dev": true,
+                      "requires": {
+                        "is-glob": "2.0.1"
+                      }
+                    }
+                  }
+                },
+                "is-dotfile": {
+                  "version": "1.0.2",
+                  "resolved": "http://52.202.166.115/i/is-dotfile/_attachments/is-dotfile-1.0.2.tgz",
+                  "integrity": "sha1-LBMjg/ORmfjtwmjKAbmwB9IFzE0=",
+                  "dev": true
+                }
+              }
+            },
+            "regex-cache": {
+              "version": "0.4.3",
+              "resolved": "http://52.202.166.115/r/regex-cache/_attachments/regex-cache-0.4.3.tgz",
+              "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+              "dev": true,
+              "requires": {
+                "is-equal-shallow": "0.1.3",
+                "is-primitive": "2.0.0"
+              },
+              "dependencies": {
+                "is-equal-shallow": {
+                  "version": "0.1.3",
+                  "resolved": "http://52.202.166.115/i/is-equal-shallow/_attachments/is-equal-shallow-0.1.3.tgz",
+                  "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-primitive": "2.0.0"
+                  }
+                },
+                "is-primitive": {
+                  "version": "2.0.0",
+                  "resolved": "http://52.202.166.115/i/is-primitive/_attachments/is-primitive-2.0.0.tgz",
+                  "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "http://52.202.166.115/m/mkdirp/_attachments/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
@@ -1572,2713 +4022,750 @@
             }
           }
         },
-        "parents": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
-          "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+        "pkg-up": {
+          "version": "1.0.0",
+          "resolved": "http://52.202.166.115/p/pkg-up/_attachments/pkg-up-1.0.0.tgz",
+          "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
           "dev": true,
           "requires": {
-            "path-platform": "0.11.15"
+            "find-up": "1.1.2"
+          }
+        },
+        "resolve-from": {
+          "version": "2.0.0",
+          "resolved": "http://52.202.166.115/r/resolve-from/_attachments/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.5.2",
+          "resolved": "http://52.202.166.115/r/rimraf/_attachments/rimraf-2.5.2.tgz",
+          "integrity": "sha1-YrqUf6TAtDY4Oa7+zU8PutYFlyY=",
+          "dev": true,
+          "requires": {
+            "glob": "7.0.3"
+          }
+        },
+        "signal-exit": {
+          "version": "2.1.2",
+          "resolved": "http://52.202.166.115/s/signal-exit/_attachments/signal-exit-2.1.2.tgz",
+          "integrity": "sha1-N1h5sfkuvDszRIDQONxUam1VhWQ=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "http://52.202.166.115/s/source-map/_attachments/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "dev": true
+        },
+        "spawn-wrap": {
+          "version": "1.2.2",
+          "resolved": "http://52.202.166.115/s/spawn-wrap/_attachments/spawn-wrap-1.2.2.tgz",
+          "integrity": "sha1-bJ5bEzhgLtYd/lGS7ZaZJT2PhBg=",
+          "dev": true,
+          "requires": {
+            "foreground-child": "1.4.0",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.1",
+            "rimraf": "2.5.2",
+            "signal-exit": "2.1.2",
+            "which": "1.2.8"
           },
           "dependencies": {
-            "path-platform": {
-              "version": "0.11.15",
-              "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-              "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+            "os-homedir": {
+              "version": "1.0.1",
+              "resolved": "http://52.202.166.115/o/os-homedir/_attachments/os-homedir-1.0.1.tgz",
+              "integrity": "sha1-DWK99EuRb9O73PLKsZGUj7CU8Ac=",
               "dev": true
             }
           }
         },
-        "process": {
-          "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz",
-          "integrity": "sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=",
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "http://52.202.166.115/s/strip-bom/_attachments/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
         },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://unpm.uberinternal.com/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+        "which": {
+          "version": "1.2.8",
+          "resolved": "http://52.202.166.115/w/which/_attachments/which-1.2.8.tgz",
+          "integrity": "sha1-N/qfbqsw5JuO9u6iRoHFeZ1S69Y=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "resolve": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
-          "integrity": "sha1-HwRCyeDLuBNuh7kwX5MvRsfygjU=",
-          "dev": true,
-          "requires": {
-            "path-parse": "1.0.5"
+            "is-absolute": "0.1.7",
+            "isexe": "1.1.2"
           },
           "dependencies": {
-            "path-parse": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-              "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-              "dev": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://unpm.uberinternal.com/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "tap-out": {
-          "version": "git://github.com/Raynos/tap-out.git#ba074212dd3da3319e07b4a32807bdd720308a4b",
-          "dev": true,
-          "requires": {
-            "re-emitter": "1.1.3",
-            "split": "0.3.3",
-            "through2": "0.6.5",
-            "trim": "0.0.1"
-          },
-          "dependencies": {
-            "re-emitter": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/re-emitter/-/re-emitter-1.1.3.tgz",
-              "integrity": "sha1-+p4xn/3u6zWycpbvDz03TawvUqc=",
-              "dev": true
-            },
-            "split": {
-              "version": "0.3.3",
-              "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-              "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+            "is-absolute": {
+              "version": "0.1.7",
+              "resolved": "http://52.202.166.115/i/is-absolute/_attachments/is-absolute-0.1.7.tgz",
+              "integrity": "sha1-hHSREZ/MtftDYhfMc39/qtUPYD8=",
               "dev": true,
               "requires": {
-                "through": "2.3.8"
+                "is-relative": "0.1.3"
               },
               "dependencies": {
-                "through": {
-                  "version": "2.3.8",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-                  "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+                "is-relative": {
+                  "version": "0.1.3",
+                  "resolved": "http://52.202.166.115/i/is-relative/_attachments/is-relative-0.1.3.tgz",
+                  "integrity": "sha1-kF/uiuhvRbPsYUvDwVyGnfCHboI=",
                   "dev": true
                 }
               }
             },
-            "through2": {
-              "version": "0.6.5",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-              "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+            "isexe": {
+              "version": "1.1.2",
+              "resolved": "http://52.202.166.115/i/isexe/_attachments/isexe-1.1.2.tgz",
+              "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
+              "dev": true
+            }
+          }
+        },
+        "yargs": {
+          "version": "4.7.0",
+          "resolved": "http://52.202.166.115/y/yargs/_attachments/yargs-4.7.0.tgz",
+          "integrity": "sha1-4zMvWstuAlJtnT3qcfbZVSuGQHE=",
+          "dev": true,
+          "requires": {
+            "camelcase": "2.1.1",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "lodash.assign": "4.0.8",
+            "os-locale": "1.4.0",
+            "pkg-conf": "1.1.2",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1",
+            "string-width": "1.0.1",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "2.1.1",
+              "resolved": "http://52.202.166.115/c/camelcase/_attachments/camelcase-2.1.1.tgz",
+              "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+              "dev": true
+            },
+            "cliui": {
+              "version": "3.2.0",
+              "resolved": "http://52.202.166.115/c/cliui/_attachments/cliui-3.2.0.tgz",
+              "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
               "dev": true,
               "requires": {
-                "readable-stream": "1.0.34",
-                "xtend": "4.0.1"
+                "string-width": "1.0.1",
+                "strip-ansi": "3.0.1",
+                "wrap-ansi": "2.0.0"
               },
               "dependencies": {
-                "readable-stream": {
-                  "version": "1.0.34",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                  "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "resolved": "http://52.202.166.115/s/strip-ansi/_attachments/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                   "dev": true,
                   "requires": {
-                    "core-util-is": "1.0.2",
-                    "inherits": "2.0.3",
-                    "isarray": "0.0.1",
-                    "string_decoder": "0.10.31"
+                    "ansi-regex": "2.0.0"
                   },
                   "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://52.202.166.115/a/ansi-regex/_attachments/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
                       "dev": true
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-                      "dev": true
-                    },
-                    "isarray": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                      "dev": true
-                    },
-                    "string_decoder": {
-                      "version": "0.10.31",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+                    }
+                  }
+                },
+                "wrap-ansi": {
+                  "version": "2.0.0",
+                  "resolved": "http://52.202.166.115/w/wrap-ansi/_attachments/wrap-ansi-2.0.0.tgz",
+                  "integrity": "sha1-fTD4+HP5pbvDpk2ryNF34HGuQm8=",
+                  "dev": true,
+                  "requires": {
+                    "string-width": "1.0.1"
+                  }
+                }
+              }
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "resolved": "http://52.202.166.115/d/decamelize/_attachments/decamelize-1.2.0.tgz",
+              "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+              "dev": true
+            },
+            "lodash.assign": {
+              "version": "4.0.8",
+              "resolved": "http://52.202.166.115/l/lodash.assign/_attachments/lodash.assign-4.0.8.tgz",
+              "integrity": "sha1-z21u3fS2v807bMeYaBUO8WTsFzM=",
+              "dev": true,
+              "requires": {
+                "lodash.keys": "4.0.6",
+                "lodash.rest": "4.0.2"
+              },
+              "dependencies": {
+                "lodash.keys": {
+                  "version": "4.0.6",
+                  "resolved": "http://52.202.166.115/l/lodash.keys/_attachments/lodash.keys-4.0.6.tgz",
+                  "integrity": "sha1-IIdpLFiw5E6IZYEI2orWb0F4Z6w=",
+                  "dev": true
+                },
+                "lodash.rest": {
+                  "version": "4.0.2",
+                  "resolved": "http://52.202.166.115/l/lodash.rest/_attachments/lodash.rest-4.0.2.tgz",
+                  "integrity": "sha1-oVp9qpy9ReIj71ul046H3QLqxr0=",
+                  "dev": true
+                }
+              }
+            },
+            "os-locale": {
+              "version": "1.4.0",
+              "resolved": "http://52.202.166.115/o/os-locale/_attachments/os-locale-1.4.0.tgz",
+              "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+              "dev": true,
+              "requires": {
+                "lcid": "1.0.0"
+              },
+              "dependencies": {
+                "lcid": {
+                  "version": "1.0.0",
+                  "resolved": "http://52.202.166.115/l/lcid/_attachments/lcid-1.0.0.tgz",
+                  "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                  "dev": true,
+                  "requires": {
+                    "invert-kv": "1.0.0"
+                  },
+                  "dependencies": {
+                    "invert-kv": {
+                      "version": "1.0.0",
+                      "resolved": "http://52.202.166.115/i/invert-kv/_attachments/invert-kv-1.0.0.tgz",
+                      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
                       "dev": true
                     }
                   }
                 }
               }
             },
-            "trim": {
-              "version": "0.0.1",
-              "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-              "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-              "dev": true
-            }
-          }
-        }
-      }
-    },
-    "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://unpm.uberinternal.com/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
-    },
-    "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://unpm.uberinternal.com/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
-      }
-    },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://unpm.uberinternal.com/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-      "dev": true,
-      "optional": true
-    },
-    "jsesc": {
-      "version": "2.5.1",
-      "resolved": "https://unpm.uberinternal.com/jsesc/-/jsesc-2.5.1.tgz",
-      "integrity": "sha1-5CGiqOINawgZ3yiQj3glJrlt0f4=",
-      "dev": true
-    },
-    "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://unpm.uberinternal.com/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-      "dev": true
-    },
-    "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://unpm.uberinternal.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-      "dev": true
-    },
-    "json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://unpm.uberinternal.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://unpm.uberinternal.com/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
-        "verror": "1.10.0"
-      }
-    },
-    "latest-version": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/latest-version/-/latest-version-2.0.0.tgz",
-      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
-      "dev": true,
-      "requires": {
-        "package-json": "2.4.0"
-      }
-    },
-    "lazy-req": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/lazy-req/-/lazy-req-1.1.0.tgz",
-      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
-      "dev": true
-    },
-    "lcov-parse": {
-      "version": "0.0.10",
-      "resolved": "https://unpm.uberinternal.com/lcov-parse/-/lcov-parse-0.0.10.tgz",
-      "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
-      "dev": true
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://unpm.uberinternal.com/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
-    },
-    "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://unpm.uberinternal.com/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
-    },
-    "log-driver": {
-      "version": "1.2.7",
-      "resolved": "https://unpm.uberinternal.com/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
-      "dev": true
-    },
-    "long": {
-      "version": "2.4.0",
-      "resolved": "https://unpm.uberinternal.com/long/-/long-2.4.0.tgz",
-      "integrity": "sha1-n6GAux2VAM3CnEFWdmoZleH0Uk8="
-    },
-    "loose-envify": {
-      "version": "1.3.1",
-      "resolved": "https://unpm.uberinternal.com/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
-    },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://unpm.uberinternal.com/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
-    },
-    "map-obj": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/map-obj/-/map-obj-2.0.0.tgz",
-      "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk="
-    },
-    "marked": {
-      "version": "0.3.19",
-      "resolved": "https://unpm.uberinternal.com/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
-      "dev": true
-    },
-    "marked-man": {
-      "version": "0.2.1",
-      "resolved": "https://unpm.uberinternal.com/marked-man/-/marked-man-0.2.1.tgz",
-      "integrity": "sha1-8lknFIHeO1ByY0ifUiG3xaz9I4M=",
-      "dev": true,
-      "requires": {
-        "marked": "0.3.19"
-      }
-    },
-    "metrics": {
-      "version": "0.1.15",
-      "resolved": "https://unpm.uberinternal.com/metrics/-/metrics-0.1.15.tgz",
-      "integrity": "sha512-Z4h1Ik8WnwVg6Zid07DUzV5S5q58htatZDEkMrNkHhoyvc05wXQlfvEHlg9cOQq2qk33lOGe1tlU33tlz2N/OA==",
-      "requires": {
-        "events": "2.1.0"
-      }
-    },
-    "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://unpm.uberinternal.com/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://unpm.uberinternal.com/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-      "dev": true,
-      "requires": {
-        "mime-db": "1.33.0"
-      }
-    },
-    "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://unpm.uberinternal.com/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://unpm.uberinternal.com/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "1.1.11"
-      }
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://unpm.uberinternal.com/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        }
-      }
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://unpm.uberinternal.com/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-      "dev": true
-    },
-    "my-local-ip": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/my-local-ip/-/my-local-ip-1.0.0.tgz",
-      "integrity": "sha1-N1hVVaT/GYUwntrHwqBFpGa+bDI="
-    },
-    "nan": {
-      "version": "2.10.0",
-      "resolved": "https://unpm.uberinternal.com/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
-    },
-    "natural-compare": {
-      "version": "1.4.0",
-      "resolved": "https://unpm.uberinternal.com/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
-      "dev": true
-    },
-    "node-status-codes": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
-      "dev": true
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
-    },
-    "nyc": {
-      "version": "12.0.2",
-      "resolved": "https://unpm.uberinternal.com/nyc/-/nyc-12.0.2.tgz",
-      "integrity": "sha1-ikpO1pCWbBHsWH/4fuoMEsl0upk=",
-      "dev": true,
-      "requires": {
-        "archy": "1.0.0",
-        "arrify": "1.0.1",
-        "caching-transform": "1.0.1",
-        "convert-source-map": "1.5.1",
-        "debug-log": "1.0.1",
-        "default-require-extensions": "1.0.0",
-        "find-cache-dir": "0.1.1",
-        "find-up": "2.1.0",
-        "foreground-child": "1.5.6",
-        "glob": "7.1.2",
-        "istanbul-lib-coverage": "1.2.0",
-        "istanbul-lib-hook": "1.1.0",
-        "istanbul-lib-instrument": "2.2.0",
-        "istanbul-lib-report": "1.1.3",
-        "istanbul-lib-source-maps": "1.2.5",
-        "istanbul-reports": "1.4.1",
-        "md5-hex": "1.3.0",
-        "merge-source-map": "1.1.0",
-        "micromatch": "3.1.10",
-        "mkdirp": "0.5.1",
-        "resolve-from": "2.0.0",
-        "rimraf": "2.6.2",
-        "signal-exit": "3.0.2",
-        "spawn-wrap": "1.4.2",
-        "test-exclude": "4.2.1",
-        "yargs": "11.1.0",
-        "yargs-parser": "8.1.0"
-      },
-      "dependencies": {
-        "align-text": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2",
-            "longest": "1.0.1",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "append-transform": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "default-require-extensions": "1.0.0"
-          }
-        },
-        "archy": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-flatten": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "arr-union": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.3.2",
-          "bundled": true,
-          "dev": true
-        },
-        "arrify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "assign-symbols": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "async": {
-          "version": "1.5.2",
-          "bundled": true,
-          "dev": true
-        },
-        "atob": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "base": {
-          "version": "0.11.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cache-base": "1.0.1",
-            "class-utils": "0.3.6",
-            "component-emitter": "1.2.1",
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "mixin-deep": "1.3.1",
-            "pascalcase": "0.1.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "1.0.2"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "6.0.2"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "6.0.2"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
-              }
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "braces": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "cache-base": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "collection-visit": "1.0.0",
-            "component-emitter": "1.2.1",
-            "get-value": "2.0.6",
-            "has-value": "1.0.0",
-            "isobject": "3.0.1",
-            "set-value": "2.0.0",
-            "to-object-path": "0.3.0",
-            "union-value": "1.0.0",
-            "unset-value": "1.0.0"
-          }
-        },
-        "caching-transform": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-hex": "1.3.0",
-            "mkdirp": "0.5.1",
-            "write-file-atomic": "1.3.4"
-          }
-        },
-        "camelcase": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "0.1.4",
-            "lazy-cache": "1.0.4"
-          }
-        },
-        "class-utils": {
-          "version": "0.3.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-union": "3.1.0",
-            "define-property": "0.2.5",
-            "isobject": "3.0.1",
-            "static-extend": "0.1.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
-            }
-          }
-        },
-        "cliui": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "collection-visit": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "map-visit": "1.0.0",
-            "object-visit": "1.0.1"
-          }
-        },
-        "commondir": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "component-emitter": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "convert-source-map": {
-          "version": "1.5.1",
-          "bundled": true,
-          "dev": true
-        },
-        "copy-descriptor": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "cross-spawn": {
-          "version": "4.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "lru-cache": "4.1.3",
-            "which": "1.3.1"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "debug-log": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "decamelize": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "decode-uri-component": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "default-require-extensions": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "strip-bom": "2.0.0"
-          }
-        },
-        "define-property": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
-          },
-          "dependencies": {
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "6.0.2"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "6.0.2"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
-              }
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "error-ex": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-arrayish": "0.2.1"
-          }
-        },
-        "execa": {
-          "version": "0.7.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          },
-          "dependencies": {
-            "cross-spawn": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "lru-cache": "4.1.3",
-                "shebang-command": "1.2.0",
-                "which": "1.3.1"
-              }
-            }
-          }
-        },
-        "expand-brackets": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-plain-object": "2.0.4"
-              }
-            }
-          }
-        },
-        "extglob": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "1.0.2"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "6.0.2"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "6.0.2"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
-              }
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "find-cache-dir": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "commondir": "1.0.1",
-            "mkdirp": "0.5.1",
-            "pkg-dir": "1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "locate-path": "2.0.0"
-          }
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "foreground-child": {
-          "version": "1.5.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cross-spawn": "4.0.2",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "fragment-cache": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "map-cache": "0.2.2"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "get-caller-file": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "get-value": {
-          "version": "2.0.6",
-          "bundled": true,
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "handlebars": {
-          "version": "4.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "async": "1.5.2",
-            "optimist": "0.6.1",
-            "source-map": "0.4.4",
-            "uglify-js": "2.8.29"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "amdefine": "1.0.1"
-              }
-            }
-          }
-        },
-        "has-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "get-value": "2.0.6",
-            "has-values": "1.0.0",
-            "isobject": "3.0.1"
-          }
-        },
-        "has-values": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
-        },
-        "hosted-git-info": {
-          "version": "2.6.0",
-          "bundled": true,
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "invert-kv": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-arrayish": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-buffer": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "builtin-modules": "1.1.1"
-          }
-        },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-odd": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "is-plain-object": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isobject": "3.0.1"
-          }
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "is-windows": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isexe": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-coverage": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "istanbul-lib-hook": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "append-transform": "0.4.0"
-          }
-        },
-        "istanbul-lib-report": {
-          "version": "1.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "istanbul-lib-coverage": "1.2.0",
-            "mkdirp": "0.5.1",
-            "path-parse": "1.0.5",
-            "supports-color": "3.2.3"
-          },
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "supports-color": {
-              "version": "3.2.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "has-flag": "1.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-lib-source-maps": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "debug": "3.1.0",
-            "istanbul-lib-coverage": "1.2.0",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2",
-            "source-map": "0.5.7"
-          }
-        },
-        "istanbul-reports": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "handlebars": "4.0.11"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "invert-kv": "1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-locate": "2.0.0",
-            "path-exists": "3.0.0"
-          },
-          "dependencies": {
-            "path-exists": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "longest": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "4.1.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
-          }
-        },
-        "map-cache": {
-          "version": "0.2.2",
-          "bundled": true,
-          "dev": true
-        },
-        "map-visit": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "object-visit": "1.0.1"
-          }
-        },
-        "md5-hex": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "md5-o-matic": "0.1.1"
-          }
-        },
-        "md5-o-matic": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "mem": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mimic-fn": "1.2.0"
-          }
-        },
-        "merge-source-map": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "source-map": "0.6.1"
-          },
-          "dependencies": {
-            "source-map": {
-              "version": "0.6.1",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "mimic-fn": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.11"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mixin-deep": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "for-in": "1.0.2",
-            "is-extendable": "1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-plain-object": "2.0.4"
-              }
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "nanomatch": {
-          "version": "1.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "fragment-cache": "0.2.1",
-            "is-odd": "2.0.0",
-            "is-windows": "1.0.2",
-            "kind-of": "6.0.2",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "2.6.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.5.0",
-            "validate-npm-package-license": "3.0.3"
-          }
-        },
-        "npm-run-path": {
-          "version": "2.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "path-key": "2.0.1"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-copy": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "copy-descriptor": "0.1.1",
-            "define-property": "0.2.5",
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
-            }
-          }
-        },
-        "object-visit": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isobject": "3.0.1"
-          }
-        },
-        "object.pick": {
-          "version": "1.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isobject": "3.0.1"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8",
-            "wordwrap": "0.0.3"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "os-locale": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "execa": "0.7.0",
-            "lcid": "1.0.0",
-            "mem": "1.1.0"
-          }
-        },
-        "p-finally": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "p-limit": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-try": "1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "p-limit": "1.2.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
-        },
-        "pascalcase": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-exists": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-key": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true
-        },
-        "path-type": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "bundled": true,
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "pinkie": "2.0.4"
-          }
-        },
-        "pkg-dir": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2"
-          },
-          "dependencies": {
-            "find-up": {
+            "pkg-conf": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "http://52.202.166.115/p/pkg-conf/_attachments/pkg-conf-1.1.2.tgz",
+              "integrity": "sha1-6CaHepwV3Hyp+gavo4zNYgOE6Sw=",
               "dev": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
-              }
-            }
-          }
-        },
-        "posix-character-classes": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "pseudomap": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
-              }
-            }
-          }
-        },
-        "regex-not": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "3.0.2",
-            "safe-regex": "1.1.0"
-          }
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true,
-          "dev": true
-        },
-        "require-directory": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "resolve-url": {
-          "version": "0.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "ret": {
-          "version": "0.1.15",
-          "bundled": true,
-          "dev": true
-        },
-        "right-align": {
-          "version": "0.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "0.1.4"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-regex": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ret": "0.1.15"
-          }
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "set-value": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "shebang-command": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "shebang-regex": "1.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "slide": {
-          "version": "1.1.6",
-          "bundled": true,
-          "dev": true
-        },
-        "snapdragon": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "base": "0.11.2",
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "map-cache": "0.2.2",
-            "source-map": "0.5.7",
-            "source-map-resolve": "0.5.2",
-            "use": "3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.6.9",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            }
-          }
-        },
-        "snapdragon-node": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "snapdragon-util": "3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "1.0.2"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "6.0.2"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "6.0.2"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
-              }
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "snapdragon-util": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true,
-          "dev": true
-        },
-        "source-map-resolve": {
-          "version": "0.5.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "atob": "2.1.1",
-            "decode-uri-component": "0.2.0",
-            "resolve-url": "0.2.1",
-            "source-map-url": "0.4.0",
-            "urix": "0.1.0"
-          }
-        },
-        "source-map-url": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true
-        },
-        "spawn-wrap": {
-          "version": "1.4.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "foreground-child": "1.5.6",
-            "mkdirp": "0.5.1",
-            "os-homedir": "1.0.2",
-            "rimraf": "2.6.2",
-            "signal-exit": "3.0.2",
-            "which": "1.3.1"
-          }
-        },
-        "spdx-correct": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-expression-parse": "3.0.0",
-            "spdx-license-ids": "3.0.0"
-          }
-        },
-        "spdx-exceptions": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "spdx-expression-parse": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-exceptions": "2.1.0",
-            "spdx-license-ids": "3.0.0"
-          }
-        },
-        "spdx-license-ids": {
-          "version": "3.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "split-string": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "extend-shallow": "3.0.2"
-          }
-        },
-        "static-extend": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-property": "0.2.5",
-            "object-copy": "0.1.0"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
-            }
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
-        },
-        "strip-eof": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "test-exclude": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arrify": "1.0.1",
-            "micromatch": "3.1.10",
-            "object-assign": "4.1.1",
-            "read-pkg-up": "1.0.1",
-            "require-main-filename": "1.0.1"
-          }
-        },
-        "to-object-path": {
-          "version": "0.3.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "to-regex": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "regex-not": "1.0.2",
-            "safe-regex": "1.1.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          },
-          "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
-                "window-size": "0.1.0"
-              }
-            }
-          }
-        },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "union-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-extendable": "0.1.1"
-              }
-            },
-            "set-value": {
-              "version": "0.4.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "to-object-path": "0.3.0"
-              }
-            }
-          }
-        },
-        "unset-value": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
-          },
-          "dependencies": {
-            "has-value": {
-              "version": "0.3.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "get-value": "2.0.6",
-                "has-values": "0.1.4",
-                "isobject": "2.1.0"
+                "find-up": "1.1.2",
+                "load-json-file": "1.1.0",
+                "object-assign": "4.1.0",
+                "symbol": "0.2.2"
               },
               "dependencies": {
-                "isobject": {
-                  "version": "2.1.0",
-                  "bundled": true,
+                "load-json-file": {
+                  "version": "1.1.0",
+                  "resolved": "http://52.202.166.115/l/load-json-file/_attachments/load-json-file-1.1.0.tgz",
+                  "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                   "dev": true,
                   "requires": {
-                    "isarray": "1.0.0"
+                    "graceful-fs": "4.1.4",
+                    "parse-json": "2.2.0",
+                    "pify": "2.3.0",
+                    "pinkie-promise": "2.0.1",
+                    "strip-bom": "2.0.0"
+                  },
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.4",
+                      "resolved": "http://52.202.166.115/g/graceful-fs/_attachments/graceful-fs-4.1.4.tgz",
+                      "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                      "dev": true
+                    },
+                    "parse-json": {
+                      "version": "2.2.0",
+                      "resolved": "http://52.202.166.115/p/parse-json/_attachments/parse-json-2.2.0.tgz",
+                      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                      "dev": true,
+                      "requires": {
+                        "error-ex": "1.3.0"
+                      },
+                      "dependencies": {
+                        "error-ex": {
+                          "version": "1.3.0",
+                          "resolved": "http://52.202.166.115/e/error-ex/_attachments/error-ex-1.3.0.tgz",
+                          "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                          "dev": true,
+                          "requires": {
+                            "is-arrayish": "0.2.1"
+                          },
+                          "dependencies": {
+                            "is-arrayish": {
+                              "version": "0.2.1",
+                              "resolved": "http://52.202.166.115/i/is-arrayish/_attachments/is-arrayish-0.2.1.tgz",
+                              "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "pify": {
+                      "version": "2.3.0",
+                      "resolved": "http://52.202.166.115/p/pify/_attachments/pify-2.3.0.tgz",
+                      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                      "dev": true
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "resolved": "http://52.202.166.115/p/pinkie-promise/_attachments/pinkie-promise-2.0.1.tgz",
+                      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                      "dev": true,
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "resolved": "http://52.202.166.115/p/pinkie/_attachments/pinkie-2.0.4.tgz",
+                          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "strip-bom": {
+                      "version": "2.0.0",
+                      "resolved": "http://52.202.166.115/s/strip-bom/_attachments/strip-bom-2.0.0.tgz",
+                      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                      "dev": true,
+                      "requires": {
+                        "is-utf8": "0.2.1"
+                      },
+                      "dependencies": {
+                        "is-utf8": {
+                          "version": "0.2.1",
+                          "resolved": "http://52.202.166.115/i/is-utf8/_attachments/is-utf8-0.2.1.tgz",
+                          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "4.1.0",
+                  "resolved": "http://52.202.166.115/o/object-assign/_attachments/object-assign-4.1.0.tgz",
+                  "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+                  "dev": true
+                },
+                "symbol": {
+                  "version": "0.2.2",
+                  "resolved": "http://52.202.166.115/s/symbol/_attachments/symbol-0.2.2.tgz",
+                  "integrity": "sha1-y9kJDnf3VdLCUOJx/9/9WXW1Ov4=",
+                  "dev": true
+                }
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "resolved": "http://52.202.166.115/r/read-pkg-up/_attachments/read-pkg-up-1.0.1.tgz",
+              "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+              "dev": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              },
+              "dependencies": {
+                "read-pkg": {
+                  "version": "1.1.0",
+                  "resolved": "http://52.202.166.115/r/read-pkg/_attachments/read-pkg-1.1.0.tgz",
+                  "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                  "dev": true,
+                  "requires": {
+                    "load-json-file": "1.1.0",
+                    "normalize-package-data": "2.3.5",
+                    "path-type": "1.1.0"
+                  },
+                  "dependencies": {
+                    "load-json-file": {
+                      "version": "1.1.0",
+                      "resolved": "http://52.202.166.115/l/load-json-file/_attachments/load-json-file-1.1.0.tgz",
+                      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.4",
+                        "parse-json": "2.2.0",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1",
+                        "strip-bom": "2.0.0"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.4",
+                          "resolved": "http://52.202.166.115/g/graceful-fs/_attachments/graceful-fs-4.1.4.tgz",
+                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                          "dev": true
+                        },
+                        "parse-json": {
+                          "version": "2.2.0",
+                          "resolved": "http://52.202.166.115/p/parse-json/_attachments/parse-json-2.2.0.tgz",
+                          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                          "dev": true,
+                          "requires": {
+                            "error-ex": "1.3.0"
+                          },
+                          "dependencies": {
+                            "error-ex": {
+                              "version": "1.3.0",
+                              "resolved": "http://52.202.166.115/e/error-ex/_attachments/error-ex-1.3.0.tgz",
+                              "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                              "dev": true,
+                              "requires": {
+                                "is-arrayish": "0.2.1"
+                              },
+                              "dependencies": {
+                                "is-arrayish": {
+                                  "version": "0.2.1",
+                                  "resolved": "http://52.202.166.115/i/is-arrayish/_attachments/is-arrayish-0.2.1.tgz",
+                                  "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "pify": {
+                          "version": "2.3.0",
+                          "resolved": "http://52.202.166.115/p/pify/_attachments/pify-2.3.0.tgz",
+                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                          "dev": true
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "resolved": "http://52.202.166.115/p/pinkie-promise/_attachments/pinkie-promise-2.0.1.tgz",
+                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "dev": true,
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "resolved": "http://52.202.166.115/p/pinkie/_attachments/pinkie-2.0.4.tgz",
+                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "strip-bom": {
+                          "version": "2.0.0",
+                          "resolved": "http://52.202.166.115/s/strip-bom/_attachments/strip-bom-2.0.0.tgz",
+                          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                          "dev": true,
+                          "requires": {
+                            "is-utf8": "0.2.1"
+                          },
+                          "dependencies": {
+                            "is-utf8": {
+                              "version": "0.2.1",
+                              "resolved": "http://52.202.166.115/i/is-utf8/_attachments/is-utf8-0.2.1.tgz",
+                              "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "normalize-package-data": {
+                      "version": "2.3.5",
+                      "resolved": "http://52.202.166.115/n/normalize-package-data/_attachments/normalize-package-data-2.3.5.tgz",
+                      "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                      "dev": true,
+                      "requires": {
+                        "hosted-git-info": "2.1.4",
+                        "is-builtin-module": "1.0.0",
+                        "semver": "5.1.0",
+                        "validate-npm-package-license": "3.0.1"
+                      },
+                      "dependencies": {
+                        "hosted-git-info": {
+                          "version": "2.1.4",
+                          "resolved": "http://52.202.166.115/h/hosted-git-info/_attachments/hosted-git-info-2.1.4.tgz",
+                          "integrity": "sha1-2elTsmmIvogJbEbpJklNlgTDAPg=",
+                          "dev": true
+                        },
+                        "is-builtin-module": {
+                          "version": "1.0.0",
+                          "resolved": "http://52.202.166.115/i/is-builtin-module/_attachments/is-builtin-module-1.0.0.tgz",
+                          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                          "dev": true,
+                          "requires": {
+                            "builtin-modules": "1.1.1"
+                          },
+                          "dependencies": {
+                            "builtin-modules": {
+                              "version": "1.1.1",
+                              "resolved": "http://52.202.166.115/b/builtin-modules/_attachments/builtin-modules-1.1.1.tgz",
+                              "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "5.1.0",
+                          "resolved": "http://52.202.166.115/s/semver/_attachments/semver-5.1.0.tgz",
+                          "integrity": "sha1-hfLPhVBGXE3wAM99hvawVBBqueU=",
+                          "dev": true
+                        },
+                        "validate-npm-package-license": {
+                          "version": "3.0.1",
+                          "resolved": "http://52.202.166.115/v/validate-npm-package-license/_attachments/validate-npm-package-license-3.0.1.tgz",
+                          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                          "dev": true,
+                          "requires": {
+                            "spdx-correct": "1.0.2",
+                            "spdx-expression-parse": "1.0.2"
+                          },
+                          "dependencies": {
+                            "spdx-correct": {
+                              "version": "1.0.2",
+                              "resolved": "http://52.202.166.115/s/spdx-correct/_attachments/spdx-correct-1.0.2.tgz",
+                              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                              "dev": true,
+                              "requires": {
+                                "spdx-license-ids": "1.2.1"
+                              },
+                              "dependencies": {
+                                "spdx-license-ids": {
+                                  "version": "1.2.1",
+                                  "resolved": "http://52.202.166.115/s/spdx-license-ids/_attachments/spdx-license-ids-1.2.1.tgz",
+                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
+                                  "dev": true
+                                }
+                              }
+                            },
+                            "spdx-expression-parse": {
+                              "version": "1.0.2",
+                              "resolved": "http://52.202.166.115/s/spdx-expression-parse/_attachments/spdx-expression-parse-1.0.2.tgz",
+                              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
+                              "dev": true,
+                              "requires": {
+                                "spdx-exceptions": "1.0.4",
+                                "spdx-license-ids": "1.2.1"
+                              },
+                              "dependencies": {
+                                "spdx-exceptions": {
+                                  "version": "1.0.4",
+                                  "resolved": "http://52.202.166.115/s/spdx-exceptions/_attachments/spdx-exceptions-1.0.4.tgz",
+                                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
+                                  "dev": true
+                                },
+                                "spdx-license-ids": {
+                                  "version": "1.2.1",
+                                  "resolved": "http://52.202.166.115/s/spdx-license-ids/_attachments/spdx-license-ids-1.2.1.tgz",
+                                  "integrity": "sha1-0H6hek0v2TUfnZTi/5zsdBgP6PM=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "path-type": {
+                      "version": "1.1.0",
+                      "resolved": "http://52.202.166.115/p/path-type/_attachments/path-type-1.1.0.tgz",
+                      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                      "dev": true,
+                      "requires": {
+                        "graceful-fs": "4.1.4",
+                        "pify": "2.3.0",
+                        "pinkie-promise": "2.0.1"
+                      },
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.4",
+                          "resolved": "http://52.202.166.115/g/graceful-fs/_attachments/graceful-fs-4.1.4.tgz",
+                          "integrity": "sha1-7widKIDwM7ARgjzlyPrnmNp3Xb0=",
+                          "dev": true
+                        },
+                        "pify": {
+                          "version": "2.3.0",
+                          "resolved": "http://52.202.166.115/p/pify/_attachments/pify-2.3.0.tgz",
+                          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                          "dev": true
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "resolved": "http://52.202.166.115/p/pinkie-promise/_attachments/pinkie-promise-2.0.1.tgz",
+                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "dev": true,
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "resolved": "http://52.202.166.115/p/pinkie/_attachments/pinkie-2.0.4.tgz",
+                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
                   }
                 }
               }
             },
-            "has-values": {
-              "version": "0.1.4",
-              "bundled": true,
+            "require-main-filename": {
+              "version": "1.0.1",
+              "resolved": "http://52.202.166.115/r/require-main-filename/_attachments/require-main-filename-1.0.1.tgz",
+              "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
               "dev": true
-            }
-          }
-        },
-        "urix": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "use": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "kind-of": "6.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.3",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "spdx-correct": "3.0.0",
-            "spdx-expression-parse": "3.0.0"
-          }
-        },
-        "which": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          }
-        },
-        "which-module": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "2.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "1.0.1"
-              }
             },
             "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
+              "version": "1.0.1",
+              "resolved": "http://52.202.166.115/s/string-width/_attachments/string-width-1.0.1.tgz",
+              "integrity": "sha1-ySEptvHX9SrPmvQkom44ZKBc6wo=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
+                "code-point-at": "1.0.0",
                 "is-fullwidth-code-point": "1.0.0",
                 "strip-ansi": "3.0.1"
+              },
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.0.0",
+                  "resolved": "http://52.202.166.115/c/code-point-at/_attachments/code-point-at-1.0.0.tgz",
+                  "integrity": "sha1-9psZLT99keOC5Lcb3bd4eGGasMY=",
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "resolved": "http://52.202.166.115/n/number-is-nan/_attachments/number-is-nan-1.0.0.tgz",
+                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
+                      "dev": true
+                    }
+                  }
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "resolved": "http://52.202.166.115/i/is-fullwidth-code-point/_attachments/is-fullwidth-code-point-1.0.0.tgz",
+                  "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                  "dev": true,
+                  "requires": {
+                    "number-is-nan": "1.0.0"
+                  },
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "resolved": "http://52.202.166.115/n/number-is-nan/_attachments/number-is-nan-1.0.0.tgz",
+                      "integrity": "sha1-wCD1KcUoKt/dIz2R1LGBw9aG3Es=",
+                      "dev": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "resolved": "http://52.202.166.115/s/strip-ansi/_attachments/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "resolved": "http://52.202.166.115/a/ansi-regex/_attachments/ansi-regex-2.0.0.tgz",
+                      "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                      "dev": true
+                    }
+                  }
+                }
               }
             },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              }
-            }
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "imurmurhash": "0.1.4",
-            "slide": "1.1.6"
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yargs": {
-          "version": "11.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "cliui": "4.1.0",
-            "decamelize": "1.2.0",
-            "find-up": "2.1.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "2.1.0",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "2.1.1",
-            "which-module": "2.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "9.0.2"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
+            "window-size": {
+              "version": "0.2.0",
+              "resolved": "http://52.202.166.115/w/window-size/_attachments/window-size-0.2.0.tgz",
+              "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
               "dev": true
             },
-            "cliui": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "wrap-ansi": "2.1.0"
-              }
+            "y18n": {
+              "version": "3.2.1",
+              "resolved": "http://52.202.166.115/y/y18n/_attachments/y18n-3.2.1.tgz",
+              "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+              "dev": true
             },
             "yargs-parser": {
-              "version": "9.0.2",
-              "bundled": true,
+              "version": "2.4.0",
+              "resolved": "http://52.202.166.115/y/yargs-parser/_attachments/yargs-parser-2.4.0.tgz",
+              "integrity": "sha1-HzZ9ycbPpWYLaXEjDzsnf8Xjrco=",
               "dev": true,
               "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "2.1.1",
+                "lodash.assign": "4.0.8"
               }
-            }
-          }
-        },
-        "yargs-parser": {
-          "version": "8.1.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "camelcase": "4.1.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "bundled": true,
-              "dev": true
             }
           }
         }
-      }
-    },
-    "oauth-sign": {
-      "version": "0.8.2",
-      "resolved": "https://unpm.uberinternal.com/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://unpm.uberinternal.com/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
-    "object-inspect": {
-      "version": "1.5.0",
-      "resolved": "https://unpm.uberinternal.com/object-inspect/-/object-inspect-1.5.0.tgz",
-      "integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw==",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://unpm.uberinternal.com/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
-      "dev": true
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://unpm.uberinternal.com/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1.0.2"
-      }
-    },
-    "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://unpm.uberinternal.com/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "1.2.0"
       }
     },
     "opn": {
       "version": "5.3.0",
       "resolved": "https://unpm.uberinternal.com/opn/-/opn-5.3.0.tgz",
-      "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+      "integrity": "sha1-ZIcVZchjh18FLP31PT48ta21Oxw=",
       "dev": true,
       "requires": {
         "is-wsl": "1.1.0"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "1.1.0",
+          "resolved": "https://unpm.uberinternal.com/is-wsl/-/is-wsl-1.1.0.tgz",
+          "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+          "dev": true
+        }
       }
-    },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://unpm.uberinternal.com/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      }
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://unpm.uberinternal.com/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://unpm.uberinternal.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://unpm.uberinternal.com/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
-    },
-    "package-json": {
-      "version": "2.4.0",
-      "resolved": "https://unpm.uberinternal.com/package-json/-/package-json-2.4.0.tgz",
-      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
-      "dev": true,
-      "requires": {
-        "got": "5.7.1",
-        "registry-auth-token": "3.3.2",
-        "registry-url": "3.1.0",
-        "semver": "5.5.0"
-      }
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://unpm.uberinternal.com/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true,
-      "requires": {
-        "error-ex": "1.3.1"
-      }
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
-    },
-    "path-is-inside": {
-      "version": "1.0.2",
-      "resolved": "https://unpm.uberinternal.com/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-      "dev": true
-    },
-    "path-parse": {
-      "version": "1.0.5",
-      "resolved": "https://unpm.uberinternal.com/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
-    },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://unpm.uberinternal.com/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-      "dev": true
-    },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://unpm.uberinternal.com/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://unpm.uberinternal.com/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://unpm.uberinternal.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "2.0.4"
-      }
-    },
-    "pluralize": {
-      "version": "7.0.0",
-      "resolved": "https://unpm.uberinternal.com/pluralize/-/pluralize-7.0.0.tgz",
-      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
-      "dev": true
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://unpm.uberinternal.com/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://unpm.uberinternal.com/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
     },
     "process": {
       "version": "0.11.10",
       "resolved": "https://unpm.uberinternal.com/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-    },
-    "progress": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/progress/-/progress-2.0.0.tgz",
-      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
-      "dev": true
-    },
-    "pseudomap": {
-      "version": "1.0.2",
-      "resolved": "https://unpm.uberinternal.com/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
-    "punycode": {
-      "version": "1.4.1",
-      "resolved": "https://unpm.uberinternal.com/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-      "dev": true
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://unpm.uberinternal.com/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
-    },
-    "quick-lru": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/quick-lru/-/quick-lru-1.1.0.tgz",
-      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g="
-    },
-    "raw-body": {
-      "version": "2.3.3",
-      "resolved": "https://unpm.uberinternal.com/raw-body/-/raw-body-2.3.3.tgz",
-      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-      "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.3",
-        "iconv-lite": "0.4.23",
-        "unpipe": "1.0.0"
-      }
-    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://unpm.uberinternal.com/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "requires": {
         "deep-extend": "0.6.0",
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
-      }
-    },
-    "read-all-stream": {
-      "version": "3.1.0",
-      "resolved": "https://unpm.uberinternal.com/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
-      "dev": true,
-      "requires": {
-        "pinkie-promise": "2.0.1",
-        "readable-stream": "2.3.6"
+      },
+      "dependencies": {
+        "deep-extend": {
+          "version": "0.6.0",
+          "resolved": "https://unpm.uberinternal.com/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
+        },
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://unpm.uberinternal.com/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://unpm.uberinternal.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+        }
       }
     },
     "readable-stream": {
       "version": "2.3.6",
       "resolved": "https://unpm.uberinternal.com/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -4287,18 +4774,46 @@
         "safe-buffer": "5.1.2",
         "string_decoder": "1.1.1",
         "util-deprecate": "1.0.2"
-      }
-    },
-    "readdirp": {
-      "version": "2.1.0",
-      "resolved": "https://unpm.uberinternal.com/readdirp/-/readdirp-2.1.0.tgz",
-      "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.6",
-        "set-immediate-shim": "1.0.1"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://unpm.uberinternal.com/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://unpm.uberinternal.com/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://unpm.uberinternal.com/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://unpm.uberinternal.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://unpm.uberinternal.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://unpm.uberinternal.com/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "requires": {
+            "safe-buffer": "5.1.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "resolved": "https://unpm.uberinternal.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+        }
       }
     },
     "ready-signal": {
@@ -4306,231 +4821,35 @@
       "resolved": "https://unpm.uberinternal.com/ready-signal/-/ready-signal-1.3.0.tgz",
       "integrity": "sha1-VUA/kg4eHyqLBloii5pj77Cjwts="
     },
-    "regexpp": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/regexpp/-/regexpp-1.1.0.tgz",
-      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
-      "dev": true
-    },
-    "registry-auth-token": {
-      "version": "3.3.2",
-      "resolved": "https://unpm.uberinternal.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-      "dev": true,
-      "requires": {
-        "rc": "1.2.8",
-        "safe-buffer": "5.1.2"
-      }
-    },
-    "registry-url": {
-      "version": "3.1.0",
-      "resolved": "https://unpm.uberinternal.com/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
-      "requires": {
-        "rc": "1.2.8"
-      }
-    },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://unpm.uberinternal.com/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "1.0.2"
-      }
-    },
-    "request": {
-      "version": "2.87.0",
-      "resolved": "https://unpm.uberinternal.com/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-      "dev": true,
-      "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
-      }
-    },
-    "require-uncached": {
-      "version": "1.0.3",
-      "resolved": "https://unpm.uberinternal.com/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      }
-    },
-    "resolve": {
-      "version": "1.5.0",
-      "resolved": "https://unpm.uberinternal.com/resolve/-/resolve-1.5.0.tgz",
-      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-      "dev": true,
-      "requires": {
-        "path-parse": "1.0.5"
-      }
-    },
-    "resolve-from": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/resolve-from/-/resolve-from-1.0.1.tgz",
-      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
-      "dev": true
-    },
-    "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
-      }
-    },
-    "resumer": {
-      "version": "0.0.0",
-      "resolved": "https://unpm.uberinternal.com/resumer/-/resumer-0.0.0.tgz",
-      "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
-      }
-    },
-    "rezult": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/rezult/-/rezult-1.1.0.tgz",
-      "integrity": "sha1-Jymr+VQoe8+6feobp5qU+/8h+2s="
-    },
-    "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://unpm.uberinternal.com/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2"
-      }
-    },
-    "run-async": {
-      "version": "2.3.0",
-      "resolved": "https://unpm.uberinternal.com/run-async/-/run-async-2.3.0.tgz",
-      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "2.1.0"
-      }
-    },
-    "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://unpm.uberinternal.com/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
-    },
-    "run-series": {
-      "version": "1.1.8",
-      "resolved": "https://unpm.uberinternal.com/run-series/-/run-series-1.1.8.tgz",
-      "integrity": "sha512-+GztYEPRpIsQoCSraWHDBs9WVy4eVME16zhOtDB4H9J4xN0XRhknnmLOl+4gRgZtu8dpp9N/utSPjKH/xmDzXg=="
-    },
-    "rust-result": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/rust-result/-/rust-result-1.0.0.tgz",
-      "integrity": "sha1-NMdbLm3Dn+WHXlveyFteD5FTb3I=",
-      "requires": {
-        "individual": "2.0.0"
-      }
-    },
-    "rx-lite": {
-      "version": "4.0.8",
-      "resolved": "https://unpm.uberinternal.com/rx-lite/-/rx-lite-4.0.8.tgz",
-      "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
-    },
-    "rx-lite-aggregates": {
-      "version": "4.0.8",
-      "resolved": "https://unpm.uberinternal.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
-      "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
-      "requires": {
-        "rx-lite": "4.0.8"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://unpm.uberinternal.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
     "safe-json-parse": {
       "version": "4.0.0",
       "resolved": "https://unpm.uberinternal.com/safe-json-parse/-/safe-json-parse-4.0.0.tgz",
       "integrity": "sha1-fA9XjPzNEtM6ccDgVBPi7KFx6qw=",
       "requires": {
         "rust-result": "1.0.0"
+      },
+      "dependencies": {
+        "rust-result": {
+          "version": "1.0.0",
+          "resolved": "https://unpm.uberinternal.com/rust-result/-/rust-result-1.0.0.tgz",
+          "integrity": "sha1-NMdbLm3Dn+WHXlveyFteD5FTb3I=",
+          "requires": {
+            "individual": "2.0.0"
+          },
+          "dependencies": {
+            "individual": {
+              "version": "2.0.0",
+              "resolved": "https://unpm.uberinternal.com/individual/-/individual-2.0.0.tgz",
+              "integrity": "sha1-gzsJfa0jKU52EXqY+zjg2a1hu5c="
+            }
+          }
+        }
       }
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://unpm.uberinternal.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
-    "semver": {
-      "version": "5.5.0",
-      "resolved": "https://unpm.uberinternal.com/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
-      "dev": true
-    },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://unpm.uberinternal.com/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
-      "requires": {
-        "semver": "5.5.0"
-      }
-    },
-    "set-immediate-shim": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
-    },
-    "setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://unpm.uberinternal.com/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://unpm.uberinternal.com/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
     },
     "shon": {
       "version": "4.0.0",
       "resolved": "https://unpm.uberinternal.com/shon/-/shon-4.0.0.tgz",
-      "integrity": "sha512-LNUpqq+iQCH9w/G7JeXUZO2NGg3FtsvmQwpUjzgE4czrsiH8GjEvVflhn7qWHgODydHW492YrSdc4QRCtvDzVQ==",
+      "integrity": "sha1-iDxu2cgUnvYkSGcFM32AVnjq5W8=",
       "requires": {
         "camelcase": "1.2.1",
         "rezult": "1.1.0"
@@ -4540,152 +4859,18 @@
           "version": "1.2.1",
           "resolved": "https://unpm.uberinternal.com/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+        },
+        "rezult": {
+          "version": "1.1.0",
+          "resolved": "https://unpm.uberinternal.com/rezult/-/rezult-1.1.0.tgz",
+          "integrity": "sha1-Jymr+VQoe8+6feobp5qU+/8h+2s="
         }
-      }
-    },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://unpm.uberinternal.com/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
-    },
-    "slice-ansi": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/slice-ansi/-/slice-ansi-1.0.0.tgz",
-      "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0"
-      }
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://unpm.uberinternal.com/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://unpm.uberinternal.com/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://unpm.uberinternal.com/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
-    },
-    "sse4_crc32": {
-      "version": "4.1.1",
-      "resolved": "https://unpm.uberinternal.com/sse4_crc32/-/sse4_crc32-4.1.1.tgz",
-      "integrity": "sha1-e+5K0iWErEs+DngbS8sV+Z+xUtE=",
-      "requires": {
-        "bindings": "1.2.1",
-        "nan": "2.10.0"
-      }
-    },
-    "sshpk": {
-      "version": "1.14.2",
-      "resolved": "https://unpm.uberinternal.com/sshpk/-/sshpk-1.14.2.tgz",
-      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-      "dev": true,
-      "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "safer-buffer": "2.1.2",
-        "tweetnacl": "0.14.5"
-      }
-    },
-    "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://unpm.uberinternal.com/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
-    },
-    "string-template": {
-      "version": "0.2.1",
-      "resolved": "https://unpm.uberinternal.com/string-template/-/string-template-0.2.1.tgz",
-      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
-    },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://unpm.uberinternal.com/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
-      }
-    },
-    "string.prototype.trim": {
-      "version": "1.1.2",
-      "resolved": "https://unpm.uberinternal.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
-      "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.12.0",
-        "function-bind": "1.1.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://unpm.uberinternal.com/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
-    "strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://unpm.uberinternal.com/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://unpm.uberinternal.com/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        }
-      }
-    },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://unpm.uberinternal.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-    },
-    "supports-color": {
-      "version": "1.3.1",
-      "resolved": "https://unpm.uberinternal.com/supports-color/-/supports-color-1.3.1.tgz",
-      "integrity": "sha1-FXWN8J2P87SswwdTn6vicJXhBC0="
-    },
-    "table": {
-      "version": "4.0.2",
-      "resolved": "https://unpm.uberinternal.com/table/-/table-4.0.2.tgz",
-      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-      "dev": true,
-      "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.4.1",
-        "lodash": "4.17.10",
-        "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
       }
     },
     "tape": {
-      "version": "4.9.0",
-      "resolved": "https://unpm.uberinternal.com/tape/-/tape-4.9.0.tgz",
-      "integrity": "sha512-j0jO9BiScfqtPBb9QmPLL0qvxXMz98xjkMb7x8lKipFlJZwNJkqkWPou+NU4V6T9RnVh1kuSthLE8gLrN8bBfw==",
+      "version": "4.9.1",
+      "resolved": "https://unpm.uberinternal.com/tape/-/tape-4.9.1.tgz",
+      "integrity": "sha1-EXPXM34EDHb79C7Ib8q+3Js4Bck=",
       "dev": true,
       "requires": {
         "deep-equal": "1.0.1",
@@ -4696,17 +4881,298 @@
         "has": "1.0.3",
         "inherits": "2.0.3",
         "minimist": "1.2.0",
-        "object-inspect": "1.5.0",
-        "resolve": "1.5.0",
+        "object-inspect": "1.6.0",
+        "resolve": "1.7.1",
         "resumer": "0.0.0",
         "string.prototype.trim": "1.1.2",
         "through": "2.3.8"
+      },
+      "dependencies": {
+        "deep-equal": {
+          "version": "1.0.1",
+          "resolved": "https://unpm.uberinternal.com/deep-equal/-/deep-equal-1.0.1.tgz",
+          "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+          "dev": true
+        },
+        "defined": {
+          "version": "1.0.0",
+          "resolved": "https://unpm.uberinternal.com/defined/-/defined-1.0.0.tgz",
+          "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+          "dev": true
+        },
+        "for-each": {
+          "version": "0.3.3",
+          "resolved": "https://unpm.uberinternal.com/for-each/-/for-each-0.3.3.tgz",
+          "integrity": "sha1-abRH6IoKXTLD5whPPxcQA0shN24=",
+          "dev": true,
+          "requires": {
+            "is-callable": "1.1.4"
+          },
+          "dependencies": {
+            "is-callable": {
+              "version": "1.1.4",
+              "resolved": "https://unpm.uberinternal.com/is-callable/-/is-callable-1.1.4.tgz",
+              "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
+              "dev": true
+            }
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "resolved": "https://unpm.uberinternal.com/function-bind/-/function-bind-1.1.1.tgz",
+          "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://unpm.uberinternal.com/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          },
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "resolved": "https://unpm.uberinternal.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+              "dev": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "resolved": "https://unpm.uberinternal.com/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+              "dev": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "https://unpm.uberinternal.com/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
+                }
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": "https://unpm.uberinternal.com/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "resolved": "https://unpm.uberinternal.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                  "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "resolved": "https://unpm.uberinternal.com/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://unpm.uberinternal.com/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "resolved": "https://unpm.uberinternal.com/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+              "dev": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              },
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "resolved": "https://unpm.uberinternal.com/wrappy/-/wrappy-1.0.2.tgz",
+                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+                  "dev": true
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "resolved": "https://unpm.uberinternal.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+              "dev": true
+            }
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "resolved": "https://unpm.uberinternal.com/has/-/has-1.0.3.tgz",
+          "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+          "dev": true,
+          "requires": {
+            "function-bind": "1.1.1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://unpm.uberinternal.com/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "object-inspect": {
+          "version": "1.6.0",
+          "resolved": "https://unpm.uberinternal.com/object-inspect/-/object-inspect-1.6.0.tgz",
+          "integrity": "sha1-xwtsv3LydKq0w0wMgvUWe/gs8Vs=",
+          "dev": true
+        },
+        "resolve": {
+          "version": "1.7.1",
+          "resolved": "https://unpm.uberinternal.com/resolve/-/resolve-1.7.1.tgz",
+          "integrity": "sha1-qt1lY3T9KYruiVvAJrgpdBhnf9M=",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          },
+          "dependencies": {
+            "path-parse": {
+              "version": "1.0.5",
+              "resolved": "https://unpm.uberinternal.com/path-parse/-/path-parse-1.0.5.tgz",
+              "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+              "dev": true
+            }
+          }
+        },
+        "resumer": {
+          "version": "0.0.0",
+          "resolved": "https://unpm.uberinternal.com/resumer/-/resumer-0.0.0.tgz",
+          "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
+          "dev": true,
+          "requires": {
+            "through": "2.3.8"
+          }
+        },
+        "string.prototype.trim": {
+          "version": "1.1.2",
+          "resolved": "https://unpm.uberinternal.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
+          "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
+          "dev": true,
+          "requires": {
+            "define-properties": "1.1.2",
+            "es-abstract": "1.12.0",
+            "function-bind": "1.1.1"
+          },
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.2",
+              "resolved": "https://unpm.uberinternal.com/define-properties/-/define-properties-1.1.2.tgz",
+              "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+              "dev": true,
+              "requires": {
+                "foreach": "2.0.5",
+                "object-keys": "1.0.12"
+              },
+              "dependencies": {
+                "foreach": {
+                  "version": "2.0.5",
+                  "resolved": "https://unpm.uberinternal.com/foreach/-/foreach-2.0.5.tgz",
+                  "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+                  "dev": true
+                },
+                "object-keys": {
+                  "version": "1.0.12",
+                  "resolved": "https://unpm.uberinternal.com/object-keys/-/object-keys-1.0.12.tgz",
+                  "integrity": "sha1-CcU4VTd1dTEMymL1W7M0q/97PtI=",
+                  "dev": true
+                }
+              }
+            },
+            "es-abstract": {
+              "version": "1.12.0",
+              "resolved": "https://unpm.uberinternal.com/es-abstract/-/es-abstract-1.12.0.tgz",
+              "integrity": "sha1-nbvdJ8aFbwABQhyhh4LXhr+KYWU=",
+              "dev": true,
+              "requires": {
+                "es-to-primitive": "1.1.1",
+                "function-bind": "1.1.1",
+                "has": "1.0.3",
+                "is-callable": "1.1.4",
+                "is-regex": "1.0.4"
+              },
+              "dependencies": {
+                "es-to-primitive": {
+                  "version": "1.1.1",
+                  "resolved": "https://unpm.uberinternal.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+                  "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+                  "dev": true,
+                  "requires": {
+                    "is-callable": "1.1.4",
+                    "is-date-object": "1.0.1",
+                    "is-symbol": "1.0.1"
+                  },
+                  "dependencies": {
+                    "is-date-object": {
+                      "version": "1.0.1",
+                      "resolved": "https://unpm.uberinternal.com/is-date-object/-/is-date-object-1.0.1.tgz",
+                      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+                      "dev": true
+                    },
+                    "is-symbol": {
+                      "version": "1.0.1",
+                      "resolved": "https://unpm.uberinternal.com/is-symbol/-/is-symbol-1.0.1.tgz",
+                      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+                      "dev": true
+                    }
+                  }
+                },
+                "is-callable": {
+                  "version": "1.1.4",
+                  "resolved": "https://unpm.uberinternal.com/is-callable/-/is-callable-1.1.4.tgz",
+                  "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
+                  "dev": true
+                },
+                "is-regex": {
+                  "version": "1.0.4",
+                  "resolved": "https://unpm.uberinternal.com/is-regex/-/is-regex-1.0.4.tgz",
+                  "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+                  "dev": true,
+                  "requires": {
+                    "has": "1.0.3"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "resolved": "https://unpm.uberinternal.com/through/-/through-2.3.8.tgz",
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+          "dev": true
+        }
       }
-    },
-    "tape-cluster": {
-      "version": "2.1.0",
-      "resolved": "https://unpm.uberinternal.com/tape-cluster/-/tape-cluster-2.1.0.tgz",
-      "integrity": "sha1-C+FBuDN09fXSX4wwfL45FrfcR/4="
     },
     "tchannel": {
       "version": "3.9.12",
@@ -4733,134 +5199,257 @@
         "xtend": "4.0.1"
       },
       "dependencies": {
+        "bufrw": {
+          "version": "1.2.1",
+          "resolved": "https://unpm.uberinternal.com/bufrw/-/bufrw-1.2.1.tgz",
+          "integrity": "sha1-k/IiIptPX14s1VkjaJFAf5hTZjs=",
+          "requires": {
+            "ansi-color": "0.2.1",
+            "error": "7.0.2",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "ansi-color": {
+              "version": "0.2.1",
+              "resolved": "https://unpm.uberinternal.com/ansi-color/-/ansi-color-0.2.1.tgz",
+              "integrity": "sha1-PnXAN0dSF1RO12Oo21cJ+prlv5o="
+            }
+          }
+        },
+        "crc": {
+          "version": "3.2.1",
+          "resolved": "https://unpm.uberinternal.com/crc/-/crc-3.2.1.tgz",
+          "integrity": "sha1-XZyPt3okXNXsopHl0tAFM0urAII="
+        },
+        "error": {
+          "version": "7.0.2",
+          "resolved": "https://unpm.uberinternal.com/error/-/error-7.0.2.tgz",
+          "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+          "requires": {
+            "string-template": "0.2.1",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "string-template": {
+              "version": "0.2.1",
+              "resolved": "https://unpm.uberinternal.com/string-template/-/string-template-0.2.1.tgz",
+              "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
+            }
+          }
+        },
+        "farmhash": {
+          "version": "1.1.0",
+          "resolved": "https://unpm.uberinternal.com/farmhash/-/farmhash-1.1.0.tgz",
+          "integrity": "sha1-8Qeb+4JOlg0wSthejfxa+zdA7ZI=",
+          "requires": {
+            "nan": "2.10.0"
+          },
+          "dependencies": {
+            "nan": {
+              "version": "2.10.0",
+              "resolved": "https://unpm.uberinternal.com/nan/-/nan-2.10.0.tgz",
+              "integrity": "sha1-ltDNYQ69WNS03pzAxoKM2pnHVI8="
+            }
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://unpm.uberinternal.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "metrics": {
+          "version": "0.1.15",
+          "resolved": "https://unpm.uberinternal.com/metrics/-/metrics-0.1.15.tgz",
+          "integrity": "sha1-Qu3ld2xFtBudm40vIN2Mm9bbW3g=",
+          "requires": {
+            "events": "2.1.0"
+          },
+          "dependencies": {
+            "events": {
+              "version": "2.1.0",
+              "resolved": "https://unpm.uberinternal.com/events/-/events-2.1.0.tgz",
+              "integrity": "sha1-KpoeGOYQbg6BKqnr1KgZs8KcC6U="
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
         "process": {
           "version": "0.11.1",
           "resolved": "https://unpm.uberinternal.com/process/-/process-0.11.1.tgz",
           "integrity": "sha1-7jvstDNe3zyLFMy/fhehElpEMa4="
+        },
+        "raw-body": {
+          "version": "2.3.3",
+          "resolved": "https://unpm.uberinternal.com/raw-body/-/raw-body-2.3.3.tgz",
+          "integrity": "sha1-GzJOzmtXBuFThVvBFIxlu39uoMM=",
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.3",
+            "iconv-lite": "0.4.23",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "bytes": {
+              "version": "3.0.0",
+              "resolved": "https://unpm.uberinternal.com/bytes/-/bytes-3.0.0.tgz",
+              "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+            },
+            "http-errors": {
+              "version": "1.6.3",
+              "resolved": "https://unpm.uberinternal.com/http-errors/-/http-errors-1.6.3.tgz",
+              "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+              "requires": {
+                "depd": "1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": "1.5.0"
+              },
+              "dependencies": {
+                "depd": {
+                  "version": "1.1.2",
+                  "resolved": "https://unpm.uberinternal.com/depd/-/depd-1.1.2.tgz",
+                  "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "resolved": "https://unpm.uberinternal.com/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                },
+                "setprototypeof": {
+                  "version": "1.1.0",
+                  "resolved": "https://unpm.uberinternal.com/setprototypeof/-/setprototypeof-1.1.0.tgz",
+                  "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
+                },
+                "statuses": {
+                  "version": "1.5.0",
+                  "resolved": "https://unpm.uberinternal.com/statuses/-/statuses-1.5.0.tgz",
+                  "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+                }
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.23",
+              "resolved": "https://unpm.uberinternal.com/iconv-lite/-/iconv-lite-0.4.23.tgz",
+              "integrity": "sha1-KXhx9jvlB63Pv8pxXQzQ7thOmmM=",
+              "requires": {
+                "safer-buffer": "2.1.2"
+              },
+              "dependencies": {
+                "safer-buffer": {
+                  "version": "2.1.2",
+                  "resolved": "https://unpm.uberinternal.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+                  "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+                }
+              }
+            },
+            "unpipe": {
+              "version": "1.0.0",
+              "resolved": "https://unpm.uberinternal.com/unpipe/-/unpipe-1.0.0.tgz",
+              "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+            }
+          }
+        },
+        "run-parallel": {
+          "version": "1.1.9",
+          "resolved": "https://unpm.uberinternal.com/run-parallel/-/run-parallel-1.1.9.tgz",
+          "integrity": "sha1-yd06fPn0ssS2JE4XOm7YZuYd1nk="
+        },
+        "run-series": {
+          "version": "1.1.8",
+          "resolved": "https://unpm.uberinternal.com/run-series/-/run-series-1.1.8.tgz",
+          "integrity": "sha1-LEVY9JIh4BzWNx/04KHiA+Rg/DY="
+        },
+        "sse4_crc32": {
+          "version": "4.1.1",
+          "resolved": "https://unpm.uberinternal.com/sse4_crc32/-/sse4_crc32-4.1.1.tgz",
+          "integrity": "sha1-e+5K0iWErEs+DngbS8sV+Z+xUtE=",
+          "requires": {
+            "bindings": "1.2.1",
+            "nan": "2.10.0"
+          },
+          "dependencies": {
+            "bindings": {
+              "version": "1.2.1",
+              "resolved": "https://unpm.uberinternal.com/bindings/-/bindings-1.2.1.tgz",
+              "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+            },
+            "nan": {
+              "version": "2.10.0",
+              "resolved": "https://unpm.uberinternal.com/nan/-/nan-2.10.0.tgz",
+              "integrity": "sha1-ltDNYQ69WNS03pzAxoKM2pnHVI8="
+            }
+          }
+        },
+        "tape-cluster": {
+          "version": "2.1.0",
+          "resolved": "https://unpm.uberinternal.com/tape-cluster/-/tape-cluster-2.1.0.tgz",
+          "integrity": "sha1-C+FBuDN09fXSX4wwfL45FrfcR/4="
+        },
+        "xorshift": {
+          "version": "0.2.1",
+          "resolved": "https://unpm.uberinternal.com/xorshift/-/xorshift-0.2.1.tgz",
+          "integrity": "sha1-/NgiZ+k1HBPw+5xzMH8lMx0pxjo="
         }
       }
-    },
-    "term-color": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/term-color/-/term-color-1.0.1.tgz",
-      "integrity": "sha1-OOGSVTpHPjXkFgT/UZmEa/gRejo=",
-      "requires": {
-        "ansi-styles": "2.0.1",
-        "supports-color": "1.3.1"
-      }
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://unpm.uberinternal.com/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
     },
     "thriftrw": {
       "version": "3.11.2",
       "resolved": "https://unpm.uberinternal.com/thriftrw/-/thriftrw-3.11.2.tgz",
-      "integrity": "sha512-3iCowlHgCEXjabCkurHTaECb2+U0V+NzqBmwfKHn8fzJJwXd/oDo7Wh6Vs0kaESN7YNJMRPC8ObL3AfQ1gxKmQ==",
+      "integrity": "sha1-aWqRlRfBZ55rq7eUsil07lEabc0=",
       "requires": {
         "bufrw": "1.2.1",
         "error": "7.0.2",
         "long": "2.4.0"
-      }
-    },
-    "through": {
-      "version": "2.3.8",
-      "resolved": "https://unpm.uberinternal.com/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
-    },
-    "timed-out": {
-      "version": "3.1.3",
-      "resolved": "https://unpm.uberinternal.com/timed-out/-/timed-out-3.1.3.tgz",
-      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
-      "dev": true
-    },
-    "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://unpm.uberinternal.com/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "1.0.2"
-      }
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
-    },
-    "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://unpm.uberinternal.com/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-      "dev": true,
-      "requires": {
-        "punycode": "1.4.1"
+      },
+      "dependencies": {
+        "bufrw": {
+          "version": "1.2.1",
+          "resolved": "https://unpm.uberinternal.com/bufrw/-/bufrw-1.2.1.tgz",
+          "integrity": "sha1-k/IiIptPX14s1VkjaJFAf5hTZjs=",
+          "requires": {
+            "ansi-color": "0.2.1",
+            "error": "7.0.2",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "ansi-color": {
+              "version": "0.2.1",
+              "resolved": "https://unpm.uberinternal.com/ansi-color/-/ansi-color-0.2.1.tgz",
+              "integrity": "sha1-PnXAN0dSF1RO12Oo21cJ+prlv5o="
+            }
+          }
+        },
+        "error": {
+          "version": "7.0.2",
+          "resolved": "https://unpm.uberinternal.com/error/-/error-7.0.2.tgz",
+          "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+          "requires": {
+            "string-template": "0.2.1",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "string-template": {
+              "version": "0.2.1",
+              "resolved": "https://unpm.uberinternal.com/string-template/-/string-template-0.2.1.tgz",
+              "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0="
+            }
+          }
+        },
+        "long": {
+          "version": "2.4.0",
+          "resolved": "https://unpm.uberinternal.com/long/-/long-2.4.0.tgz",
+          "integrity": "sha1-n6GAux2VAM3CnEFWdmoZleH0Uk8="
+        }
       }
     },
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://unpm.uberinternal.com/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://unpm.uberinternal.com/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
-    "trycatch": {
-      "version": "1.5.11",
-      "resolved": "https://unpm.uberinternal.com/trycatch/-/trycatch-1.5.11.tgz",
-      "integrity": "sha1-unfr8Y8QyrQ5bAzsUkvfa5Mq5Z0=",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "1.1.0",
-        "hookit": "0.1.3"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "1.1.0",
-          "resolved": "https://unpm.uberinternal.com/ansi-styles/-/ansi-styles-1.1.0.tgz",
-          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
-          "dev": true,
-          "optional": true
-        }
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://unpm.uberinternal.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://unpm.uberinternal.com/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-      "dev": true,
-      "optional": true
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://unpm.uberinternal.com/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://unpm.uberinternal.com/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
     },
     "uber-licence": {
       "version": "3.1.1",
@@ -4874,213 +5463,707 @@
         "update-notifier": "1.0.3"
       },
       "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
         "process": {
           "version": "0.10.1",
           "resolved": "https://unpm.uberinternal.com/process/-/process-0.10.1.tgz",
           "integrity": "sha1-hCRXzFHP7XLcd1r+6vuMYDQ3JyU=",
           "dev": true
+        },
+        "readdirp": {
+          "version": "2.1.0",
+          "resolved": "https://unpm.uberinternal.com/readdirp/-/readdirp-2.1.0.tgz",
+          "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.4",
+            "readable-stream": "2.3.6",
+            "set-immediate-shim": "1.0.1"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.11",
+              "resolved": "https://unpm.uberinternal.com/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+              "dev": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "resolved": "https://unpm.uberinternal.com/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "1.1.11"
+              },
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.11",
+                  "resolved": "https://unpm.uberinternal.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
+                  "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+                  "dev": true,
+                  "requires": {
+                    "balanced-match": "1.0.0",
+                    "concat-map": "0.0.1"
+                  },
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "resolved": "https://unpm.uberinternal.com/balanced-match/-/balanced-match-1.0.0.tgz",
+                      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+                      "dev": true
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "resolved": "https://unpm.uberinternal.com/concat-map/-/concat-map-0.0.1.tgz",
+                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "set-immediate-shim": {
+              "version": "1.0.1",
+              "resolved": "https://unpm.uberinternal.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+              "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+              "dev": true
+            }
+          }
+        },
+        "update-notifier": {
+          "version": "1.0.3",
+          "resolved": "https://unpm.uberinternal.com/update-notifier/-/update-notifier-1.0.3.tgz",
+          "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
+          "dev": true,
+          "requires": {
+            "boxen": "0.6.0",
+            "chalk": "1.1.3",
+            "configstore": "2.1.0",
+            "is-npm": "1.0.0",
+            "latest-version": "2.0.0",
+            "lazy-req": "1.1.0",
+            "semver-diff": "2.1.0",
+            "xdg-basedir": "2.0.0"
+          },
+          "dependencies": {
+            "boxen": {
+              "version": "0.6.0",
+              "resolved": "https://unpm.uberinternal.com/boxen/-/boxen-0.6.0.tgz",
+              "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
+              "dev": true,
+              "requires": {
+                "ansi-align": "1.1.0",
+                "camelcase": "2.1.1",
+                "chalk": "1.1.3",
+                "cli-boxes": "1.0.0",
+                "filled-array": "1.1.0",
+                "object-assign": "4.1.1",
+                "repeating": "2.0.1",
+                "string-width": "1.0.2",
+                "widest-line": "1.0.0"
+              },
+              "dependencies": {
+                "ansi-align": {
+                  "version": "1.1.0",
+                  "resolved": "https://unpm.uberinternal.com/ansi-align/-/ansi-align-1.1.0.tgz",
+                  "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
+                  "dev": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
+                },
+                "camelcase": {
+                  "version": "2.1.1",
+                  "resolved": "https://unpm.uberinternal.com/camelcase/-/camelcase-2.1.1.tgz",
+                  "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+                  "dev": true
+                },
+                "cli-boxes": {
+                  "version": "1.0.0",
+                  "resolved": "https://unpm.uberinternal.com/cli-boxes/-/cli-boxes-1.0.0.tgz",
+                  "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+                  "dev": true
+                },
+                "filled-array": {
+                  "version": "1.1.0",
+                  "resolved": "https://unpm.uberinternal.com/filled-array/-/filled-array-1.1.0.tgz",
+                  "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q=",
+                  "dev": true
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "resolved": "https://unpm.uberinternal.com/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                  "dev": true
+                },
+                "repeating": {
+                  "version": "2.0.1",
+                  "resolved": "https://unpm.uberinternal.com/repeating/-/repeating-2.0.1.tgz",
+                  "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+                  "dev": true,
+                  "requires": {
+                    "is-finite": "1.0.2"
+                  },
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.2",
+                      "resolved": "https://unpm.uberinternal.com/is-finite/-/is-finite-1.0.2.tgz",
+                      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+                      "dev": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "resolved": "https://unpm.uberinternal.com/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "resolved": "https://unpm.uberinternal.com/string-width/-/string-width-1.0.2.tgz",
+                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                  "dev": true,
+                  "requires": {
+                    "code-point-at": "1.1.0",
+                    "is-fullwidth-code-point": "1.0.0",
+                    "strip-ansi": "3.0.1"
+                  },
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.1.0",
+                      "resolved": "https://unpm.uberinternal.com/code-point-at/-/code-point-at-1.1.0.tgz",
+                      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+                      "dev": true
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "resolved": "https://unpm.uberinternal.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                      "dev": true,
+                      "requires": {
+                        "number-is-nan": "1.0.1"
+                      },
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "resolved": "https://unpm.uberinternal.com/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "resolved": "https://unpm.uberinternal.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "dev": true,
+                      "requires": {
+                        "ansi-regex": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "resolved": "https://unpm.uberinternal.com/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "widest-line": {
+                  "version": "1.0.0",
+                  "resolved": "https://unpm.uberinternal.com/widest-line/-/widest-line-1.0.0.tgz",
+                  "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+                  "dev": true,
+                  "requires": {
+                    "string-width": "1.0.2"
+                  }
+                }
+              }
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://unpm.uberinternal.com/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "2.2.1",
+                "escape-string-regexp": "1.0.5",
+                "has-ansi": "2.0.0",
+                "strip-ansi": "3.0.1",
+                "supports-color": "2.0.0"
+              },
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "resolved": "https://unpm.uberinternal.com/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                  "dev": true
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "resolved": "https://unpm.uberinternal.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+                  "dev": true
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "resolved": "https://unpm.uberinternal.com/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "resolved": "https://unpm.uberinternal.com/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "resolved": "https://unpm.uberinternal.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                  "dev": true,
+                  "requires": {
+                    "ansi-regex": "2.1.1"
+                  },
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "resolved": "https://unpm.uberinternal.com/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "resolved": "https://unpm.uberinternal.com/supports-color/-/supports-color-2.0.0.tgz",
+                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                  "dev": true
+                }
+              }
+            },
+            "configstore": {
+              "version": "2.1.0",
+              "resolved": "https://unpm.uberinternal.com/configstore/-/configstore-2.1.0.tgz",
+              "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+              "dev": true,
+              "requires": {
+                "dot-prop": "3.0.0",
+                "graceful-fs": "4.1.11",
+                "mkdirp": "0.5.1",
+                "object-assign": "4.1.1",
+                "os-tmpdir": "1.0.2",
+                "osenv": "0.1.5",
+                "uuid": "2.0.3",
+                "write-file-atomic": "1.3.4",
+                "xdg-basedir": "2.0.0"
+              },
+              "dependencies": {
+                "dot-prop": {
+                  "version": "3.0.0",
+                  "resolved": "https://unpm.uberinternal.com/dot-prop/-/dot-prop-3.0.0.tgz",
+                  "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+                  "dev": true,
+                  "requires": {
+                    "is-obj": "1.0.1"
+                  },
+                  "dependencies": {
+                    "is-obj": {
+                      "version": "1.0.1",
+                      "resolved": "https://unpm.uberinternal.com/is-obj/-/is-obj-1.0.1.tgz",
+                      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+                      "dev": true
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "resolved": "https://unpm.uberinternal.com/graceful-fs/-/graceful-fs-4.1.11.tgz",
+                  "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+                  "dev": true
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "resolved": "https://unpm.uberinternal.com/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+                  "dev": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "resolved": "https://unpm.uberinternal.com/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                      "dev": true
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "resolved": "https://unpm.uberinternal.com/object-assign/-/object-assign-4.1.1.tgz",
+                  "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                  "dev": true
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "resolved": "https://unpm.uberinternal.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+                  "dev": true
+                },
+                "osenv": {
+                  "version": "0.1.5",
+                  "resolved": "https://unpm.uberinternal.com/osenv/-/osenv-0.1.5.tgz",
+                  "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+                  "dev": true,
+                  "requires": {
+                    "os-homedir": "1.0.2",
+                    "os-tmpdir": "1.0.2"
+                  },
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.2",
+                      "resolved": "https://unpm.uberinternal.com/os-homedir/-/os-homedir-1.0.2.tgz",
+                      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                      "dev": true
+                    }
+                  }
+                },
+                "uuid": {
+                  "version": "2.0.3",
+                  "resolved": "https://unpm.uberinternal.com/uuid/-/uuid-2.0.3.tgz",
+                  "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+                  "dev": true
+                },
+                "write-file-atomic": {
+                  "version": "1.3.4",
+                  "resolved": "https://unpm.uberinternal.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+                  "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "imurmurhash": "0.1.4",
+                    "slide": "1.1.6"
+                  },
+                  "dependencies": {
+                    "imurmurhash": {
+                      "version": "0.1.4",
+                      "resolved": "https://unpm.uberinternal.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
+                      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+                      "dev": true
+                    },
+                    "slide": {
+                      "version": "1.1.6",
+                      "resolved": "https://unpm.uberinternal.com/slide/-/slide-1.1.6.tgz",
+                      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "is-npm": {
+              "version": "1.0.0",
+              "resolved": "https://unpm.uberinternal.com/is-npm/-/is-npm-1.0.0.tgz",
+              "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+              "dev": true
+            },
+            "latest-version": {
+              "version": "2.0.0",
+              "resolved": "https://unpm.uberinternal.com/latest-version/-/latest-version-2.0.0.tgz",
+              "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+              "dev": true,
+              "requires": {
+                "package-json": "2.4.0"
+              },
+              "dependencies": {
+                "package-json": {
+                  "version": "2.4.0",
+                  "resolved": "https://unpm.uberinternal.com/package-json/-/package-json-2.4.0.tgz",
+                  "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
+                  "dev": true,
+                  "requires": {
+                    "got": "5.7.1",
+                    "registry-auth-token": "3.3.2",
+                    "registry-url": "3.1.0",
+                    "semver": "5.5.0"
+                  },
+                  "dependencies": {
+                    "got": {
+                      "version": "5.7.1",
+                      "resolved": "https://unpm.uberinternal.com/got/-/got-5.7.1.tgz",
+                      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+                      "dev": true,
+                      "requires": {
+                        "create-error-class": "3.0.2",
+                        "duplexer2": "0.1.4",
+                        "is-redirect": "1.0.0",
+                        "is-retry-allowed": "1.1.0",
+                        "is-stream": "1.1.0",
+                        "lowercase-keys": "1.0.1",
+                        "node-status-codes": "1.0.0",
+                        "object-assign": "4.1.1",
+                        "parse-json": "2.2.0",
+                        "pinkie-promise": "2.0.1",
+                        "read-all-stream": "3.1.0",
+                        "readable-stream": "2.3.6",
+                        "timed-out": "3.1.3",
+                        "unzip-response": "1.0.2",
+                        "url-parse-lax": "1.0.0"
+                      },
+                      "dependencies": {
+                        "create-error-class": {
+                          "version": "3.0.2",
+                          "resolved": "https://unpm.uberinternal.com/create-error-class/-/create-error-class-3.0.2.tgz",
+                          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+                          "dev": true,
+                          "requires": {
+                            "capture-stack-trace": "1.0.0"
+                          },
+                          "dependencies": {
+                            "capture-stack-trace": {
+                              "version": "1.0.0",
+                              "resolved": "https://unpm.uberinternal.com/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+                              "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "duplexer2": {
+                          "version": "0.1.4",
+                          "resolved": "https://unpm.uberinternal.com/duplexer2/-/duplexer2-0.1.4.tgz",
+                          "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+                          "dev": true,
+                          "requires": {
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "is-redirect": {
+                          "version": "1.0.0",
+                          "resolved": "https://unpm.uberinternal.com/is-redirect/-/is-redirect-1.0.0.tgz",
+                          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+                          "dev": true
+                        },
+                        "is-retry-allowed": {
+                          "version": "1.1.0",
+                          "resolved": "https://unpm.uberinternal.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+                          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+                          "dev": true
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "resolved": "https://unpm.uberinternal.com/is-stream/-/is-stream-1.1.0.tgz",
+                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+                          "dev": true
+                        },
+                        "lowercase-keys": {
+                          "version": "1.0.1",
+                          "resolved": "https://unpm.uberinternal.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+                          "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+                          "dev": true
+                        },
+                        "node-status-codes": {
+                          "version": "1.0.0",
+                          "resolved": "https://unpm.uberinternal.com/node-status-codes/-/node-status-codes-1.0.0.tgz",
+                          "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
+                          "dev": true
+                        },
+                        "object-assign": {
+                          "version": "4.1.1",
+                          "resolved": "https://unpm.uberinternal.com/object-assign/-/object-assign-4.1.1.tgz",
+                          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                          "dev": true
+                        },
+                        "parse-json": {
+                          "version": "2.2.0",
+                          "resolved": "https://unpm.uberinternal.com/parse-json/-/parse-json-2.2.0.tgz",
+                          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                          "dev": true,
+                          "requires": {
+                            "error-ex": "1.3.2"
+                          },
+                          "dependencies": {
+                            "error-ex": {
+                              "version": "1.3.2",
+                              "resolved": "https://unpm.uberinternal.com/error-ex/-/error-ex-1.3.2.tgz",
+                              "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+                              "dev": true,
+                              "requires": {
+                                "is-arrayish": "0.2.1"
+                              },
+                              "dependencies": {
+                                "is-arrayish": {
+                                  "version": "0.2.1",
+                                  "resolved": "https://unpm.uberinternal.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                  "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+                                  "dev": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "resolved": "https://unpm.uberinternal.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "dev": true,
+                          "requires": {
+                            "pinkie": "2.0.4"
+                          },
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "resolved": "https://unpm.uberinternal.com/pinkie/-/pinkie-2.0.4.tgz",
+                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+                              "dev": true
+                            }
+                          }
+                        },
+                        "read-all-stream": {
+                          "version": "3.1.0",
+                          "resolved": "https://unpm.uberinternal.com/read-all-stream/-/read-all-stream-3.1.0.tgz",
+                          "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+                          "dev": true,
+                          "requires": {
+                            "pinkie-promise": "2.0.1",
+                            "readable-stream": "2.3.6"
+                          }
+                        },
+                        "timed-out": {
+                          "version": "3.1.3",
+                          "resolved": "https://unpm.uberinternal.com/timed-out/-/timed-out-3.1.3.tgz",
+                          "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
+                          "dev": true
+                        },
+                        "unzip-response": {
+                          "version": "1.0.2",
+                          "resolved": "https://unpm.uberinternal.com/unzip-response/-/unzip-response-1.0.2.tgz",
+                          "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+                          "dev": true
+                        },
+                        "url-parse-lax": {
+                          "version": "1.0.0",
+                          "resolved": "https://unpm.uberinternal.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+                          "dev": true,
+                          "requires": {
+                            "prepend-http": "1.0.4"
+                          },
+                          "dependencies": {
+                            "prepend-http": {
+                              "version": "1.0.4",
+                              "resolved": "https://unpm.uberinternal.com/prepend-http/-/prepend-http-1.0.4.tgz",
+                              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "registry-auth-token": {
+                      "version": "3.3.2",
+                      "resolved": "https://unpm.uberinternal.com/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+                      "integrity": "sha1-hR/UkDjuy1hpERFa+EUmDuyYPyA=",
+                      "dev": true,
+                      "requires": {
+                        "rc": "1.2.8",
+                        "safe-buffer": "5.1.2"
+                      },
+                      "dependencies": {
+                        "safe-buffer": {
+                          "version": "5.1.2",
+                          "resolved": "https://unpm.uberinternal.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                          "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+                          "dev": true
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "3.1.0",
+                      "resolved": "https://unpm.uberinternal.com/registry-url/-/registry-url-3.1.0.tgz",
+                      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+                      "dev": true,
+                      "requires": {
+                        "rc": "1.2.8"
+                      }
+                    },
+                    "semver": {
+                      "version": "5.5.0",
+                      "resolved": "https://unpm.uberinternal.com/semver/-/semver-5.5.0.tgz",
+                      "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
+                      "dev": true
+                    }
+                  }
+                }
+              }
+            },
+            "lazy-req": {
+              "version": "1.1.0",
+              "resolved": "https://unpm.uberinternal.com/lazy-req/-/lazy-req-1.1.0.tgz",
+              "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
+              "dev": true
+            },
+            "semver-diff": {
+              "version": "2.1.0",
+              "resolved": "https://unpm.uberinternal.com/semver-diff/-/semver-diff-2.1.0.tgz",
+              "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+              "dev": true,
+              "requires": {
+                "semver": "5.5.0"
+              },
+              "dependencies": {
+                "semver": {
+                  "version": "5.5.0",
+                  "resolved": "https://unpm.uberinternal.com/semver/-/semver-5.5.0.tgz",
+                  "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
+                  "dev": true
+                }
+              }
+            },
+            "xdg-basedir": {
+              "version": "2.0.0",
+              "resolved": "https://unpm.uberinternal.com/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+              "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+              "dev": true,
+              "requires": {
+                "os-homedir": "1.0.2"
+              },
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "resolved": "https://unpm.uberinternal.com/os-homedir/-/os-homedir-1.0.2.tgz",
+                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+                  "dev": true
+                }
+              }
+            }
+          }
         }
       }
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-    },
-    "unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://unpm.uberinternal.com/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-      "dev": true
-    },
-    "update-notifier": {
-      "version": "1.0.3",
-      "resolved": "https://unpm.uberinternal.com/update-notifier/-/update-notifier-1.0.3.tgz",
-      "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
-      "dev": true,
-      "requires": {
-        "boxen": "0.6.0",
-        "chalk": "1.1.3",
-        "configstore": "2.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "2.0.0",
-        "lazy-req": "1.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://unpm.uberinternal.com/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://unpm.uberinternal.com/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://unpm.uberinternal.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://unpm.uberinternal.com/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
-      }
-    },
-    "url-parse-lax": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "requires": {
-        "prepend-http": "1.0.4"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://unpm.uberinternal.com/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "uuid": {
-      "version": "3.2.1",
-      "resolved": "https://unpm.uberinternal.com/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
-      "dev": true
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://unpm.uberinternal.com/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "dev": true,
-      "requires": {
-        "assert-plus": "1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
-      }
-    },
-    "which": {
-      "version": "1.3.1",
-      "resolved": "https://unpm.uberinternal.com/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
-      "requires": {
-        "isexe": "2.0.0"
-      }
-    },
-    "widest-line": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/widest-line/-/widest-line-1.0.0.tgz",
-      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
-      "dev": true,
-      "requires": {
-        "string-width": "1.0.2"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://unpm.uberinternal.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://unpm.uberinternal.com/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://unpm.uberinternal.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        }
-      }
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://unpm.uberinternal.com/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://unpm.uberinternal.com/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "write": {
-      "version": "0.2.1",
-      "resolved": "https://unpm.uberinternal.com/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
-    },
-    "write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://unpm.uberinternal.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "slide": "1.1.6"
-      }
-    },
-    "xdg-basedir": {
-      "version": "2.0.0",
-      "resolved": "https://unpm.uberinternal.com/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
-    },
-    "xorshift": {
-      "version": "0.2.1",
-      "resolved": "https://unpm.uberinternal.com/xorshift/-/xorshift-0.2.1.tgz",
-      "integrity": "sha1-/NgiZ+k1HBPw+5xzMH8lMx0pxjo="
     },
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://unpm.uberinternal.com/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://unpm.uberinternal.com/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     }
   ],
   "dependencies": {
-    "camelcase-keys": "^4.2.0",
+    "camelcase-keys": "^1.0.0",
     "debug-logtron": "^5.2.0",
     "my-local-ip": "^1.0.0",
     "process": "^0.11.0",
@@ -35,11 +35,11 @@
   },
   "devDependencies": {
     "coveralls": "^3.0.1",
-    "eslint": "^4.19.1",
+    "eslint": "^1.9.1",
     "format-stack": "4.1.1",
     "itape": "^1.5.0",
     "marked-man": "^0.2.1",
-    "nyc": "12.0.2",
+    "nyc": "6.4.4",
     "opn": "^5.3.0",
     "ready-signal": "^1.2.0",
     "tape": "^4.9.0",


### PR DESCRIPTION
There were some recent changes that made tcurl compatible for node ^8 but broke it for 0.10. Since this is essentially EOL, we should make sure the dependencies work for 0.10, other versions shouldn't matter.

Signed-off-by: Won Jun Jang <wjang@uber.com>